### PR TITLE
API spec updated: /token/{id} supports only delete method

### DIFF
--- a/api_spec.yml
+++ b/api_spec.yml
@@ -305,25 +305,17 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /tokens/{id}:
-    put:
-      summary: Change the token's state (e.g. revoke)
+    delete:
+      summary: Delete token
       parameters:
         - name: id
           in: path
           description: Unique token identifier.
           required: true
           type: string
-        - name: token
-          in: body
-          description: Token descriptor.
-          required: true
-          schema:
-            $ref: "#/definitions/TokenDescriptor"
       responses:
-        200:
-          description: Token successfully updated.
-        400:
-          description: Missing/malformed request params.
+        204:
+          description: Token successfully deleted.
         404:
           description: Token not found.
           schema:


### PR DESCRIPTION
Token revoketion results in token deletion not in token state update.
It is only possible to delete token throug API.
There is no need to have token updates possible anymore.
MEN-464

Signed-off-by: Krzysztof Jaskiewicz krzysztof.jaskiewicz@rndity.com
