### PR TITLE
middleware: allow Accept header to be passed in CORS request

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -117,6 +117,7 @@ func SetupMiddleware(api *rest.Api, mwtype string) error {
 
 		// Allowed headers
 		AllowedHeaders: []string{
+			"Accept",
 			"Allow",
 			"Content-Type",
 			"Origin",


### PR DESCRIPTION
This is the same change as in device admission service.
