### PR TITLE
DevAdm communication error propagation

### DIFF
--- a/client_deviceadm.go
+++ b/client_deviceadm.go
@@ -76,7 +76,7 @@ func (d *DevAdmClient) AddDevice(dev *Device, client requestid.ApiRequester) err
 	defer rsp.Body.Close()
 
 	if rsp.StatusCode != http.StatusCreated {
-		return errors.Wrapf(err,
+		return errors.Errorf(
 			"device add request failed with status %v", rsp.Status)
 	}
 	return nil

--- a/client_deviceadm_test.go
+++ b/client_deviceadm_test.go
@@ -37,7 +37,7 @@ func TestGetDevAdmClient(t *testing.T) {
 }
 
 func TestDevAdmClientReqSuccess(t *testing.T) {
-	s := newMockServer(200)
+	s := newMockServer(http.StatusCreated)
 	defer s.Close()
 
 	addDevUrl := s.URL + "/devices"
@@ -50,7 +50,7 @@ func TestDevAdmClientReqSuccess(t *testing.T) {
 }
 
 func TestDevAdmClientReqFail(t *testing.T) {
-	s := newMockServer(400)
+	s := newMockServer(http.StatusBadRequest)
 	defer s.Close()
 
 	addDevUrl := s.URL + "/devices"
@@ -59,7 +59,7 @@ func TestDevAdmClientReqFail(t *testing.T) {
 	})
 
 	err := c.AddDevice(&Device{}, &http.Client{})
-	assert.NoError(t, err, "expected an error")
+	assert.Error(t, err, "expected an error")
 }
 
 func TestDevAdmClientReqNoHost(t *testing.T) {


### PR DESCRIPTION
DevAdm integration failures should also fail requests.

@maciejmrowiec @bboozzoo @mchalski  @marekswiecznik
