### PR TITLE
devauth: handle case when device is in DB but no authorization reques…

### DIFF
--- a/devauth.go
+++ b/devauth.go
@@ -223,7 +223,7 @@ func (d *DevAuth) verifySeqNo(dev_id string, seq_no uint64) error {
 		return errors.Wrap(err, "db get auth requests error")
 	}
 
-	if r != nil {
+	if len(r) > 0 {
 		if seq_no <= r[0].SeqNo {
 			return ErrDevAuthUnauthorized
 		}


### PR DESCRIPTION
…ts were stored

Handle an endge case when a device is present in DB, but there are no
registered authorization requests. In this case, the preliminary checks
returned a device, no errors yet, then we queried for registered
authorization requests, but that returned an empty slice. With Go magic,
empty slice is not nil, but nil slice is empty (len() for both is 0).

@maciejmrowiec @kjaskiewiczz @mchalski @marekswiecznik 
