### PR TITLE
doc: fix allowed device state transistions section

### DIFF
--- a/docs/api_spec.yml
+++ b/docs/api_spec.yml
@@ -219,6 +219,7 @@ paths:
         - pending -> accepted
         - pending -> rejected
         - rejected -> accepted
+        - accepted -> rejected
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
accepted -> rejected is allowed as a way of revoking the device's access to the system

Signed-off-by: mchalczynski marcin.chalczynski@rndity.com
