### PR TITLE
Cleanup API for submitting device for admission

### DIFF
--- a/api_devauth.go
+++ b/api_devauth.go
@@ -242,6 +242,8 @@ func (d *DevAuthHandler) UpdateDeviceStatusHandler(w rest.ResponseWriter, r *res
 		err = da.WithContext(ctx).AcceptDevice(devid)
 	} else if status.Status == DevStatusRejected {
 		err = da.RejectDevice(devid)
+	} else if status.Status == DevStatusPending {
+		err = da.ResetDevice(devid)
 	}
 	if err != nil {
 		if err == ErrDevNotFound {
@@ -292,9 +294,11 @@ func restErrWithLogMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e 
 // Expected statuses:
 // - "accepted"
 // - "rejected"
+// - "pending"
 func statusValidate(status *DevAuthApiStatus) error {
 	if status.Status != DevStatusAccepted &&
-		status.Status != DevStatusRejected {
+		status.Status != DevStatusRejected &&
+		status.Status != DevStatusPending {
 		return ErrIncorrectStatus
 	} else {
 		return nil

--- a/api_devauth_mock_test.go
+++ b/api_devauth_mock_test.go
@@ -24,6 +24,7 @@ type MockDevAuth struct {
 	mockSubmitAuthRequestWithClient func(r *AuthReq, c requestid.ApiRequester) (string, error)
 	mockAcceptDevice                func(dev_id string) error
 	mockRejectDevice                func(dev_id string) error
+	mockResetDevice                 func(dev_id string) error
 	mockVerifyToken                 func(token string) error
 	mockRevokeToken                 func(tokenId string) error
 	mockWithContext                 func(ctx *RequestContext) DevAuthApp
@@ -55,6 +56,10 @@ func (mda *MockDevAuth) AcceptDevice(dev_id string) error {
 
 func (mda *MockDevAuth) RejectDevice(dev_id string) error {
 	return mda.mockRejectDevice(dev_id)
+}
+
+func (mda *MockDevAuth) ResetDevice(dev_id string) error {
+	return mda.mockResetDevice(dev_id)
 }
 
 func (mda *MockDevAuth) GetDeviceToken(dev_id string) (*Token, error) {

--- a/api_devauth_test.go
+++ b/api_devauth_test.go
@@ -284,6 +284,7 @@ func TestApiDevAuthUpdateStatusDevice(t *testing.T) {
 	devauth := MockDevAuth{
 		mockAcceptDevice: mockaction,
 		mockRejectDevice: mockaction,
+		mockResetDevice:  mockaction,
 	}
 	devauth.mockWithContext = func(ctx *RequestContext) DevAuthApp {
 		return &devauth
@@ -299,6 +300,7 @@ func TestApiDevAuthUpdateStatusDevice(t *testing.T) {
 
 	accstatus := DevAuthApiStatus{"accepted"}
 	rejstatus := DevAuthApiStatus{"rejected"}
+	penstatus := DevAuthApiStatus{"pending"}
 
 	tcases := []struct {
 		req     *http.Request
@@ -346,6 +348,15 @@ func TestApiDevAuthUpdateStatusDevice(t *testing.T) {
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/foo/status",
 				rejstatus),
+			code: 303,
+			headers: map[string]string{
+				"Location": "http://1.2.3.4/api/0.1.0/devices/foo",
+			},
+		},
+		{
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/0.1.0/devices/foo/status",
+				penstatus),
 			code: 303,
 			headers: map[string]string{
 				"Location": "http://1.2.3.4/api/0.1.0/devices/foo",

--- a/client_deviceadm.go
+++ b/client_deviceadm.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// devices endpoint
-	DevAdmDevicesUri = "/api/0.1.0/devices"
+	DevAdmDevicesUri = "/api/0.1.0/devices/"
 	// default request timeout, 10s?
 	defaultDevAdmReqTimeout = time.Duration(10) * time.Second
 )
@@ -52,7 +52,6 @@ func (d *DevAdmClient) AddDevice(dev *Device, client requestid.ApiRequester) err
 	d.log.Debugf("add device %s for admission", dev.Id)
 
 	AdmReqJson, err := json.Marshal(AdmReq{
-		Id:     dev.Id,
 		IdData: dev.IdData,
 		PubKey: dev.PubKey,
 	})
@@ -63,8 +62,8 @@ func (d *DevAdmClient) AddDevice(dev *Device, client requestid.ApiRequester) err
 	contentReader := bytes.NewReader(AdmReqJson)
 
 	req, err := http.NewRequest(
-		http.MethodPost,
-		utils.JoinURL(d.conf.DevAdmAddr, DevAdmDevicesUri),
+		http.MethodPut,
+		utils.JoinURL(d.conf.DevAdmAddr, DevAdmDevicesUri+dev.Id),
 		contentReader)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create request")

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -17,11 +17,7 @@ paths:
       description: |
         Sets the status of a given device to the selected value.
 
-        Valid transitions:
-        * 'pending' -> 'accepted'
-        * 'pending' -> 'rejected'
-        * 'accepted' -> 'rejected'
-        * 'rejected' -> 'accepted'
+        All possible transitions are valid.
 
       parameters:
         - name: id

--- a/model_admreq.go
+++ b/model_admreq.go
@@ -14,7 +14,6 @@
 package main
 
 type AdmReq struct {
-	Id     string `json:"id"`
 	IdData string `json:"device_identity"`
 	PubKey string `json:"key"`
 }


### PR DESCRIPTION
* enable setting `pending` status in API for a device (and update docs)
* update `deviceadm` client to conform https://github.com/mendersoftware/deviceadm/pull/45 changes
* add ResetDevice method for setting `pending` status

Issues: MEN-650

@mchalski @maciejmrowiec 