### PR TITLE
acceptance tests seqnum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,13 +123,13 @@ script:
     - sudo docker build -t $DOCKER_REPOSITORY .
 
     # Build acceptance tests container
-    - ./tests/build-acceptance ./tests
+    - ./tests/build-acceptance ./tests ./docs/internal_api.yml
 
     # Clone integration repo. for api testing (purposely after license checking..)
     - git clone https://github.com/mendersoftware/integration.git
 
-    # Run dependant microservices and the service itself
-    - ./tests/run-acceptance $PWD/integration ./docs/internal_api.yml
+    # Run dependant microservices and the tests service itself
+    - TESTS_DIR=$PWD/tests ./tests/run-acceptance $PWD/integration ./tests/docker-compose.yml
 
 after_success:
     # Integrate with https://codecov.io

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,61 @@
+# Acceptance tests
+
+Acceptance tests are run in a separate container within the same network as all
+other Mender services. For this to work, acceptance tests container needs to be
+described in its own `docker-compose` file. The whole setup is started as a
+separate compose project named `acceptance-tests`.
+
+The tests container service is expected to be named `acceptance`. Dependencies
+on other services, networks, aliases need to be defined in the compose file.
+Example definition of acceptance tests container for Device Auth service:
+
+```
+version: '2'
+services:
+    acceptance:
+        image: testing
+        networks:
+            - mender
+        volumes:
+            - "${TESTS_DIR}:/testing"
+        depends_on:
+            - mender-device-adm
+            - mender-device-auth
+            - mender-inventory
+
+```
+
+## Building
+
+Build docker image for your service, use the same tag as is used
+in [integration](https://github.com/mendersoftware/integration) repository
+setup.
+   
+Build acceptance tests container using `build-acceptance` script. The script
+takes 2 parameters: a path to the location where acceptance tests `Dockerfile`
+is placed and a list of extra files to copy to tests directory.
+
+`Dockerfile` defines `/testing/run.sh` as container entry point. Make sure that
+the path is a valid.
+
+`build-acceptance` script tags the built image using name `testing`. The same
+name needs to be used for container `image` in tests compose file.
+   
+## Running
+
+Use `run-acceptance` script. The script takes 2 parameters: the path to
+integration repository (we need to access docker-compose of the whole stack)
+and a path to compose file that describes acceptance tests container.
+
+It is possible to use environment variable expansion in tests compose file. Make
+sure to set appropriate variables when running `run-acceptance`.
+
+## Example
+
+Assume that the user is at the top of device auth source code, integration was
+cloned to `../integration`. The following commands will build and run acceptance
+tests:
+
+- `./tests/build-acceptance ./tests ./docs/internal_api.yml`
+
+- `TESTS_DIR=$PWD/tests ./tests/run-acceptance ../integration ./tests/docker-compose.yml`

--- a/tests/build-acceptance
+++ b/tests/build-acceptance
@@ -2,11 +2,21 @@
 
 set -e
 
+SELFDIR=$(readlink -f $(dirname $0))
+
 DIR=$1
 
 [ -n "$DIR" ] || {
-    echo "usage: $(basename $0) <path-to-docker-dir>"
+    echo "usage: $(basename $0) <path-to-docker-dir> [<extra-files-to-copy>...]"
     exit 1
 }
+shift
+
+if [ $# -ne 0 ]; then
+    echo "-- copying extra files"
+    for f in $*; do
+        cp -v $f $SELFDIR
+    done
+fi
 
 (cd $DIR && docker build -t testing .)

--- a/tests/common.py
+++ b/tests/common.py
@@ -57,9 +57,9 @@ class Device(object):
 
 
 class DevAuthorizer(object):
-    def __init__(self):
+    def __init__(self, seqno=None):
         self.tenant_token = "dummy"
-        self.seqno = count(1)
+        self.seqno = seqno or count(1)
 
     def make_req_payload(self, dev):
         """Make auth request for given device. Returns a tuple (payload, signature)"""

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -6,3 +6,7 @@ services:
             - mender
         volumes:
             - "${TESTS_DIR}:/testing"
+        depends_on:
+            - mender-device-adm
+            - mender-device-auth
+            - mender-inventory

--- a/tests/run-acceptance
+++ b/tests/run-acceptance
@@ -42,9 +42,6 @@ DEPS=${DEPS:-"mender-device-adm mender-device-auth mender-inventory"}
 
 COMPOSE_CMD="docker-compose -p acceptance-tests -f $INTEGRATION_PATH/docker-compose.yml"
 
-# spin up the environment
-$COMPOSE_CMD up -d $DEPS
-
 # start acceptance tests container
 TESTS_DIR=$SELFDIR \
          $COMPOSE_CMD -f $SELFDIR/docker-compose.yml run acceptance || failed=1

--- a/tests/run-acceptance
+++ b/tests/run-acceptance
@@ -5,7 +5,7 @@ set -e
 SELFDIR=$(readlink -f $(dirname $0))
 
 usage() {
-    echo "usage: $(basename $0) <path-to-integration> [<file-to-copy>]"
+    echo "usage: $(basename $0) <path-to-integration> <path-to-acceptance-compose-file>]"
     echo
     echo "  Sets up acceptance tests environment and runs tests defined"
     echo "  in directory:"
@@ -31,20 +31,20 @@ INTEGRATION_PATH=$1
 }
 shift
 
-if [ $# -ne 0 ]; then
-    echo "-- copying extra files"
-    for f in $*; do
-        cp -v $f $SELFDIR
-    done
-fi
+TESTS_COMPOSE_PATH=$1
 
-DEPS=${DEPS:-"mender-device-adm mender-device-auth mender-inventory"}
+[ -z "$TESTS_COMPOSE_PATH" -o ! -f "$TESTS_COMPOSE_PATH" ] && {
+    echo "tests compose path not provided"
+    usage
+    exit 1
+}
+shift
 
 COMPOSE_CMD="docker-compose -p acceptance-tests -f $INTEGRATION_PATH/docker-compose.yml"
+TEST_SERVICE=${TEST_SERVICE:-"acceptance"}
 
 # start acceptance tests container
-TESTS_DIR=$SELFDIR \
-         $COMPOSE_CMD -f $SELFDIR/docker-compose.yml run acceptance || failed=1
+$COMPOSE_CMD -f $TESTS_COMPOSE_PATH run ${TEST_SERVICE} || failed=1
 
 # fold everything
 [ -z "$NO_CLEANUP" ] && $COMPOSE_CMD down || true

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,5 +14,4 @@ fi
 py.test-3 -s --tb=short --api=0.1.0  --host $HOST \
         --spec $DIR/internal_api.yml \
         --verbose --junitxml=$DIR/results.xml \
-        $DIR/tests/test_device.py \
-        $DIR/tests/test_token.py
+        $DIR/tests/test_*.py

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,6 +11,8 @@ if [ -n "$1" ]; then
     HOST=$1
 fi
 
+sleep 5
+
 py.test-3 -s --tb=short --api=0.1.0  --host $HOST \
         --spec $DIR/internal_api.yml \
         --verbose --junitxml=$DIR/results.xml \

--- a/tests/tests/test_token.py
+++ b/tests/tests/test_token.py
@@ -81,7 +81,7 @@ class TestToken(Client):
         rsp = requests.delete(self.make_api_url('/tokens/{}'.format(tclaims['jti'])))
         assert rsp.status_code == 204
 
-        # successful verification
+        # unsuccessful verification
         rsp = requests.post(verify_url, data='',
                             headers={'Authorization': auth_hdr})
         assert rsp.status_code == 401


### PR DESCRIPTION
@mendersoftware/rndity @GregorioDiStefano 

I've tried to generalize `run-acceptance` so that it could become a part of integration repository rather than that of a specific service. This led to minor changes in `build-acceptance`. The script is supposed to build the image for acceptance tests container. So any image/service specific pieces (like copy of extra files) were moved there.

On top of this, there's a readme detailing running and building processes.