### PR TITLE
Remove use of docker-compose before integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,17 +150,12 @@ script:
         TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose.yml;
       fi
 
-    # Run dependant microservices and the tests service itself
-    - if [[ "$JOB_TYPE" = compile_and_integration_tests* ]]; then
-        NO_CLEANUP=true TESTS_DIR=$PWD/tests ./tests/run-test-environment "integration" $PWD/integration ./tests/docker-compose-integration.yml &
-      fi
-
     - if [ "$JOB_TYPE" = compile_and_integration_tests_fast ]; then
-        ( cd $PWD/integration/tests && bash run.sh fast );
+        ( cd $PWD/integration/tests && bash run.sh --runfast --docker-compose-file=../../tests/docker-compose-integration.yml );
       fi
 
     - if [ "$JOB_TYPE" = compile_and_integration_tests_slow ]; then
-        ( cd $PWD/integration/tests && bash run.sh slow );
+        ( cd $PWD/integration/tests && bash run.sh --runslow --docker-compose-file=../../tests/docker-compose-integration.yml );
       fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ script:
     - CGO_ENABLED=0 go build -ldflags "-X main.Commit=`echo $TRAVIS_COMMIT` -X main.Tag=`echo $TRAVIS_TAG` -X main.Branch=`echo $TRAVIS_BRANCH` -X main.BuildNumber=`echo $TRAVIS_BUILD_NUMBER`"
 
     # Build docker image from docker file
-    - sudo docker build -t $DOCKER_REPOSITORY .
+    - sudo docker build -t $DOCKER_REPOSITORY:pr .
 
     # Clone integration repo. for api testing (purposely after license checking..)
     - git clone https://github.com/mendersoftware/integration.git
@@ -172,7 +172,7 @@ after_success:
 before_deploy:
     # Master is always lastest
     - if [ ! -z "$TRAVIS_TAG" ]; then export IMAGE_TAG=$TRAVIS_TAG; else export IMAGE_TAG=$TRAVIS_BRANCH; fi
-    - docker tag $DOCKER_REPOSITORY $DOCKER_REPOSITORY:$IMAGE_TAG
+    - docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$IMAGE_TAG
 
     # Upload image to docker registry only on PUSH
     - docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD

--- a/tests/docker-compose-integration.yml
+++ b/tests/docker-compose-integration.yml
@@ -2,4 +2,4 @@ version: '2'
 services:
     mender-device-auth:
             # built/tagged locally and only used for testing
-            image: mendersoftware/deviceauth
+            image: mendersoftware/deviceauth:pr


### PR DESCRIPTION
This is done inside the tests themselves now.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>