### PR TITLE
devauth: api: log ID and key mismatch

### DIFF
--- a/api_devauth.go
+++ b/api_devauth.go
@@ -137,8 +137,10 @@ func (d *DevAuthHandler) SubmitAuthRequestHandler(w rest.ResponseWriter, r *rest
 	ctx := ContextFromRequest(r)
 	token, err := da.WithContext(ctx).SubmitAuthRequest(&authreq)
 	switch err {
-	case ErrDevAuthUnauthorized:
-		restErrWithLogMsg(w, r, l, err, http.StatusUnauthorized, "unauthorized")
+	case ErrDevAuthUnauthorized, ErrDevAuthIdKeyMismatch, ErrDevAuthKeyMismatch:
+		// error is always set to unauthorized, client does not need to
+		// know why
+		restErrWithLogMsg(w, r, l, ErrDevAuthUnauthorized, http.StatusUnauthorized, "unauthorized")
 		return
 	case nil:
 		w.(http.ResponseWriter).Write([]byte(token))

--- a/devauth.go
+++ b/devauth.go
@@ -24,7 +24,9 @@ import (
 )
 
 var (
-	ErrDevAuthUnauthorized = errors.New("dev auth: unauthorized")
+	ErrDevAuthUnauthorized  = errors.New("dev auth: unauthorized")
+	ErrDevAuthKeyMismatch   = errors.New("dev auth: device key mismatch")
+	ErrDevAuthIdKeyMismatch = errors.New("dev auth: ID and key mismatch")
 )
 
 // TODO:
@@ -173,10 +175,15 @@ func (d *DevAuth) findMatchingDevice(id, key string) (*Device, error) {
 	if devi == nil && devk == nil {
 		return nil, nil
 	} else if devi != nil && devk != nil {
-		if devi.Id == devk.Id &&
-			devi.PubKey == devk.PubKey {
-			return devi, nil
+		if devi.Id != devk.Id {
+			return nil, ErrDevAuthIdKeyMismatch
 		}
+
+		if devi.PubKey != devk.PubKey {
+			return nil, ErrDevAuthKeyMismatch
+		}
+
+		return devi, nil
 	}
 
 	return nil, ErrDevAuthUnauthorized

--- a/devauth_test.go
+++ b/devauth_test.go
@@ -146,7 +146,7 @@ func TestSubmitAuthRequest(t *testing.T) {
 			devAdmErr: nil,
 
 			res: "",
-			err: ErrDevAuthUnauthorized,
+			err: ErrDevAuthIdKeyMismatch,
 		},
 		{
 			//existing device, id duplicate + key mismatch
@@ -169,7 +169,7 @@ func TestSubmitAuthRequest(t *testing.T) {
 			devAdmErr: nil,
 
 			res: "",
-			err: ErrDevAuthUnauthorized,
+			err: ErrDevAuthKeyMismatch,
 		},
 		{
 			//existing, accepted device, but wrong seq_no


### PR DESCRIPTION
Distinguish cases where there's a different device ID, but the same device
key (device identity data has changed) and same device ID but different
key (device key changed).

The first case may happen when the end user is using device attributes that are
not immutable (ex. ethernet MAC address of Raspberry Pi is changed on each
boot).

The second case corresponds to key rotation, which is not yet handled.

@mendersoftware/rndity @maciejmrowiec 