### PR TITLE
MEN-963 Versioning

### DIFF
--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,6 +1,7 @@
 #
 # Apache-2.0
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  LICENSE
+b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 bbb303820971c294a9a8e5eba5affcf1379036e877ea61c11cbf9400b2949483  vendor/github.com/mendersoftware/mendertesting/LICENSE
 b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 

--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -1,12 +1,12 @@
 swagger: '2.0'
 info:
-  version: '0.1'
+  version: '1'
   title: Device authentication
   description: |
     An API for device authentication handling. Intended for use by devices.
 
-basePath: '/api/devices/0.1/authentication'
-host: 'docker.mender.io:8080'
+basePath: '/api/devices/v1/authentication'
+host: 'docker.mender.io'
 schemes:
   - https
 

--- a/middleware.go
+++ b/middleware.go
@@ -22,6 +22,7 @@ import (
 	dlog "github.com/mendersoftware/deviceauth/log"
 	"github.com/mendersoftware/deviceauth/requestid"
 	"github.com/mendersoftware/deviceauth/requestlog"
+	"github.com/mendersoftware/go-lib-micro/customheader"
 )
 
 const (
@@ -81,7 +82,13 @@ var (
 )
 
 func SetupMiddleware(api *rest.Api, mwtype string) error {
+
 	l := dlog.New(dlog.Ctx{})
+
+	api.Use(&customheader.CustomHeaderMiddleware{
+		HeaderName:  "X-AUTHENTICATION-VERSION",
+		HeaderValue: CreateVersionString(),
+	})
 
 	l.Infof("setting up %s middleware", mwtype)
 

--- a/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package customheader
+
+import "github.com/ant0ine/go-json-rest/rest"
+
+// Add custom HTTP header to all server responses
+type CustomHeaderMiddleware struct {
+	HeaderName  string
+	HeaderValue string
+}
+
+// MiddlewareFunc makes CustomHeaderMiddleware implement the Middleware interface.
+func (c *CustomHeaderMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
+	return func(w rest.ResponseWriter, r *rest.Request) {
+
+		if len(c.HeaderName) > 0 {
+			w.Header().Add(c.HeaderName, c.HeaderValue)
+		}
+
+		// call the handler
+		h(w, r)
+	}
+}

--- a/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware_test.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package customheader
+
+import (
+	"testing"
+
+	"github.com/ant0ine/go-json-rest/rest"
+	"github.com/ant0ine/go-json-rest/rest/test"
+)
+
+func TestCustomHeaderMiddleware(t *testing.T) {
+
+	testCases := map[string]struct {
+		Name  string
+		Value string
+	}{
+		"empty": {},
+		"no value": {
+			Name: "MyName",
+		},
+		"both": {
+			Name:  "MyName",
+			Value: "Lala",
+		},
+	}
+
+	for name, tc := range testCases {
+
+		t.Run(name, func(t *testing.T) {
+
+			api := rest.NewApi()
+
+			api.Use(&CustomHeaderMiddleware{
+				HeaderName:  tc.Name,
+				HeaderValue: tc.Value,
+			})
+
+			api.SetApp(rest.AppSimple(func(w rest.ResponseWriter, r *rest.Request) {
+				w.WriteJson(map[string]string{"Id": "123"})
+			}))
+
+			handler := api.MakeHandler()
+
+			req := test.MakeSimpleRequest("GET", "http://localhost/", nil)
+			recorded := test.RunRequest(t, handler, req)
+			recorded.CodeIs(200)
+			recorded.ContentTypeIsJson()
+			recorded.HeaderIs(tc.Name, tc.Value)
+		})
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,11 +3,18 @@
 	"ignore": "",
 	"package": [
 		{
+			"checksumSHA1": "XvmQkFe1S3yAa451K+06MqPkfyk=",
+			"path": "github.com/mendersoftware/go-lib-micro/customheader",
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
+		},
+		{
 			"checksumSHA1": "AslGZd/VnH8RZgPcgpB+cbxEeKc=",
 			"path": "github.com/mendersoftware/go-lib-micro/mongo/migrate",
 			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
 			"revisionTime": "2017-01-30T12:11:14Z"
 		}
+		
 	],
 	"rootPath": "github.com/mendersoftware/deviceauth"
 }


### PR DESCRIPTION
Change public routing to v1, v2, v3 schema (v1).
Update documentation.
Remove port 8080 from swagger.
Add service version header returned by API

@mendersoftware/rndity 