### PR TITLE
devauth: support device reauthentication on key & sequence number change

### DIFF
--- a/devauth_test.go
+++ b/devauth_test.go
@@ -322,6 +322,10 @@ func TestSubmitAuthRequest(t *testing.T) {
 			mockDeleteTokenByDevId: func(dev_id string) error {
 				return nil
 			},
+
+			mockUpdateDevice: func(d *Device) error {
+				return nil
+			},
 		}
 
 		cda := MockDevAdmClient{


### PR DESCRIPTION
Device public key change or sequence number reset is a possible scenario that
may easily be caused by wiping on-device mender client state data.

When this occurs, we will keep rejecting device's authentication request. It is
also not possible to reauthenticate the device, unless user removes it from the
system or it is decomissioned. Unfortunately, none of this is possible right now.

This change allows for device reauthentication if:
- sequence number verification fails
- device public key has changed

If any of these conditions takes place, device status is reset to pending (hence
all authentication will be rejected) and a request is sent to device admission
service. Device has to go through the admission procedure again in order to
get authentication token.


Please discuss.
@estenberg @pasinskim @maciejmrowiec @kacf @mendersoftware/rndity 

Edit: there is not jira ticket that covers this.

Edit2: don't blindly merge it yet