### PR TITLE
api: internal: no See Other on device status PUT

### DIFF
--- a/api_devauth.go
+++ b/api_devauth.go
@@ -235,8 +235,7 @@ func (d *DevAuthHandler) UpdateDeviceStatusHandler(w rest.ResponseWriter, r *res
 		return
 	}
 
-	w.Header().Add("Location", "../"+devid)
-	w.WriteHeader(http.StatusSeeOther)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // return selected http code + error message directly taken from error

--- a/api_devauth_test.go
+++ b/api_devauth_test.go
@@ -303,73 +303,60 @@ func TestApiDevAuthUpdateStatusDevice(t *testing.T) {
 	penstatus := DevAuthApiStatus{"pending"}
 
 	tcases := []struct {
-		req     *http.Request
-		code    int
-		body    string
-		headers map[string]string
+		req  *http.Request
+		code int
+		body string
 	}{
 		{
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/foo/status", nil),
-			code: 400,
+			code: http.StatusBadRequest,
 			body: RestError("failed to decode status data: JSON payload is empty"),
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/foo/status",
 				DevAuthApiStatus{"foo"}),
-			code: 400,
+			code: http.StatusBadRequest,
 			body: RestError("incorrect device status"),
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/foo/status",
 				accstatus),
-			code: 303,
-			headers: map[string]string{
-				"Location": "../foo",
-			},
+			code: http.StatusNoContent,
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/bar/status",
 				accstatus),
-			code: 500,
+			code: http.StatusInternalServerError,
 			body: RestError("internal error"),
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/baz/status",
 				accstatus),
-			code: 404,
+			code: http.StatusNotFound,
 			body: RestError(ErrDevNotFound.Error()),
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/foo/status",
 				rejstatus),
-			code: 303,
-			headers: map[string]string{
-				"Location": "../foo",
-			},
+			code: http.StatusNoContent,
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
 				"http://1.2.3.4/api/0.1.0/devices/foo/status",
 				penstatus),
-			code: 303,
-			headers: map[string]string{
-				"Location": "../foo",
-			},
+			code: http.StatusNoContent,
 		},
 	}
 
 	for idx, tc := range tcases {
 		t.Logf("running %d", idx)
-		recorded := runTestRequest(t, apih, tc.req, tc.code, tc.body)
-		for h, v := range tc.headers {
-			recorded.HeaderIs(h, v)
-		}
+		runTestRequest(t, apih, tc.req, tc.code, tc.body)
 	}
 
 }

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -32,12 +32,8 @@ paths:
           schema:
             $ref: '#/definitions/Status'
       responses:
-        303:
+        204:
           description: The device status was successfully updated.
-          headers:
-            Location:
-              type: string
-              description: URI of the updated device.
         400:
           description: Bad request.
           schema:

--- a/tests/tests/test_device.py
+++ b/tests/tests/test_device.py
@@ -48,7 +48,7 @@ class TestDevice(Client):
         try:
             self.accept_device(devid)
         except bravado.exception.HTTPError as e:
-            assert e.response.status_code == 200
+            assert e.response.status_code == 204
 
         # device is accepted, we should get a token now
         rsp = device_auth_req(url, da, d)
@@ -63,7 +63,7 @@ class TestDevice(Client):
         try:
             self.reject_device(devid)
         except bravado.exception.HTTPError as e:
-            assert e.response.status_code == 200
+            assert e.response.status_code == 204
 
         # device is rejected, should get unauthorized
         rsp = device_auth_req(url, da, d)

--- a/tests/tests/test_token.py
+++ b/tests/tests/test_token.py
@@ -29,7 +29,7 @@ class TestToken(Client):
         try:
             self.accept_device(devid)
         except bravado.exception.HTTPError as e:
-            assert e.response.status_code == 200
+            assert e.response.status_code == 204
 
         # device is accepted, we should get a token now
         rsp = device_auth_req(url, da, d)
@@ -105,7 +105,7 @@ class TestToken(Client):
         try:
             self.accept_device(devid)
         except bravado.exception.HTTPError as e:
-            assert e.response.status_code == 200
+            assert e.response.status_code == 204
 
         # device is accepted, but we're going to request a token using the same
         # sequence number as before


### PR DESCRIPTION
Do not return 303 See Other on PUT to /api/0.1.0/devices/:id/status as this
would redirect to an endpoint that no longer exists.

@mendersoftware/rndity @maciejmrowiec 