### PR TITLE
decommissioning fix

### DIFF
--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -255,8 +255,10 @@ func (d *DevAuth) DecommissionDevice(ctx context.Context, devId string) error {
 	l.Warnf("Decommission device with id: %s", devId)
 
 	// set decommissioning flag on the device
-	updev := &model.Device{Id: devId, Decommissioning: true}
-	if err := d.db.UpdateDevice(ctx, updev); err != nil {
+	updev := model.DeviceUpdate{
+		Decommissioning: to.BoolPtr(true),
+	}
+	if err := d.db.UpdateDevice(ctx, model.Device{Id: devId}, updev); err != nil {
 		return err
 	}
 

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -404,5 +404,16 @@ func (d *DevAuth) VerifyToken(ctx context.Context, token string) error {
 		return jwt.ErrTokenInvalid
 	}
 
+	// reject authentication for device that is in the process of
+	// decommissioning
+	dev, err := d.db.GetDeviceById(ctx, auth.DeviceId)
+	if err != nil {
+		return err
+	}
+	if dev.Decommissioning {
+		l.Errorf("token %v rejected, device %s is being decommissioned", jti, auth.DeviceId)
+		return jwt.ErrTokenInvalid
+	}
+
 	return nil
 }

--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -656,7 +656,9 @@ func TestDevAuthDecommissionDevice(t *testing.T) {
 			co.On("SubmitDeviceDecommisioningJob", context.Background(), mock.AnythingOfType("orchestrator.DecommissioningReq")).Return(
 				tc.coSubmitDeviceDecommisioningJobErr)
 			db := mstore.DataStore{}
-			db.On("UpdateDevice", context.Background(), mock.AnythingOfType("*model.Device")).Return(
+			db.On("UpdateDevice", context.Background(),
+				mock.AnythingOfType("model.Device"),
+				mock.AnythingOfType("model.DeviceUpdate")).Return(
 				tc.dbUpdateDeviceErr)
 			db.On("DeleteAuthSetsForDevice", context.Background(), mock.AnythingOfType("string")).Return(
 				tc.dbDeleteAuthSetsForDeviceErr)

--- a/jwt/jwt_agent.go
+++ b/jwt/jwt_agent.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	ErrTokenExpired = errors.New("jwt: token expired")
-	ErrTokenInvalid = errors.New("jwt: token ivalid")
+	ErrTokenInvalid = errors.New("jwt: token invalid")
 )
 
 // Token field names

--- a/model/device.go
+++ b/model/device.go
@@ -39,6 +39,15 @@ type Device struct {
 	AuthSets        []AuthSet `json:"auth_sets" bson:"-"`
 }
 
+type DeviceUpdate struct {
+	TenantToken     string     `json:"-" bson:"tenant_token,omitempty"`
+	PubKey          string     `json:"-" bson:",omitempty"`
+	IdData          string     `json:"id_data" bson:"id_data,omitempty"`
+	Status          string     `json:"-" bson:",omitempty"`
+	Decommissioning *bool      `json:"-" bson:",omitempty"`
+	UpdatedTs       *time.Time `json:"updated_ts" bson:"updated_ts,omitempty"`
+}
+
 func NewDevice(id, id_data, pubkey, tenant_token string) *Device {
 	now := time.Now()
 

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -46,9 +46,8 @@ type DataStore interface {
 
 	AddDevice(ctx context.Context, d model.Device) error
 
-	// updates a single device selected via d.Id
-	// updates only set fields
-	UpdateDevice(ctx context.Context, d *model.Device) error
+	// updates a single device with ID `d.Id`, using data from `up`
+	UpdateDevice(ctx context.Context, d model.Device, up model.DeviceUpdate) error
 
 	// deletes device
 	DeleteDevice(ctx context.Context, id string) error

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -11,10 +11,6 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-
-// generate with:
-// mockery -name=DataStore
-
 package mocks
 
 import context "context"
@@ -300,13 +296,13 @@ func (_m *DataStore) UpdateAuthSet(ctx context.Context, orig model.AuthSet, mod 
 	return r0
 }
 
-// UpdateDevice provides a mock function with given fields: ctx, d
-func (_m *DataStore) UpdateDevice(ctx context.Context, d *model.Device) error {
-	ret := _m.Called(ctx, d)
+// UpdateDevice provides a mock function with given fields: ctx, d, up
+func (_m *DataStore) UpdateDevice(ctx context.Context, d model.Device, up model.DeviceUpdate) error {
+	ret := _m.Called(ctx, d, up)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *model.Device) error); ok {
-		r0 = rf(ctx, d)
+	if rf, ok := ret.Get(0).(func(context.Context, model.Device, model.DeviceUpdate) error); ok {
+		r0 = rf(ctx, d, up)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Details are covered in commit 
https://github.com/mendersoftware/deviceauth/commit/41d4aec24a25521719661a0b1a20e4de09d694aa

Note that there is still a chance that device will be created in inventory if attributes PATCH request goes through token verification before decommissioning commenced but the actual requested is proxied to inventory after DELETE device was run. Fixing this would require a change in how PATCH on device attributes works.

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 

Best if verifed with https://github.com/mendersoftware/mender-api-gateway-docker/pull/64 otherwise correlating all logs with their corresponding requests may not be accurate.