### PR TITLE
get max devices limit (mgmt endpoint)

### DIFF
--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -338,6 +338,13 @@ func (d *DevAuthApiHandlers) PutTenantLimitHandler(w rest.ResponseWriter, r *res
 	tenantId := r.PathParam("id")
 	reqLimitName := r.PathParam("name")
 
+	if !model.IsValidLimit(reqLimitName) {
+		rest_utils.RestErrWithLog(w, r, l,
+			errors.Errorf("unsupported limit %v", reqLimitName),
+			http.StatusBadRequest)
+		return
+	}
+
 	var value LimitValue
 	err := r.DecodeJsonPayload(&value)
 	if err != nil {
@@ -348,17 +355,7 @@ func (d *DevAuthApiHandlers) PutTenantLimitHandler(w rest.ResponseWriter, r *res
 
 	limit := model.Limit{
 		Value: value.Limit,
-	}
-
-	if reqLimitName == "max-device-count" {
-		limit.Name = model.LimitMaxDeviceCount
-	}
-
-	if limit.Name == "" {
-		rest_utils.RestErrWithLog(w, r, l,
-			errors.Errorf("unsupported limit %v", reqLimitName),
-			http.StatusBadRequest)
-		return
+		Name:  reqLimitName,
 	}
 
 	if err := d.devAuth.SetTenantLimit(ctx, tenantId, limit); err != nil {

--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -37,6 +37,7 @@ const (
 	uriDevice       = "/api/management/v1/devauth/devices/:id"
 	uriToken        = "/api/management/v1/devauth/tokens/:id"
 	uriDeviceStatus = "/api/management/v1/devauth/devices/:id/auth/:aid/status"
+	uriLimit        = "/api/management/v1/devauth/limits/:name"
 
 	// internal API
 	uriTokenVerify = "/api/internal/v1/devauth/tokens/verify"
@@ -81,6 +82,8 @@ func (d *DevAuthApiHandlers) GetApp() (rest.App, error) {
 		rest.Put(uriDeviceStatus, d.UpdateDeviceStatusHandler),
 
 		rest.Put(uriTenantLimit, d.PutTenantLimitHandler),
+
+		rest.Get(uriLimit, d.GetLimit),
 	}
 
 	app, err := rest.MakeRouter(
@@ -364,6 +367,29 @@ func (d *DevAuthApiHandlers) PutTenantLimitHandler(w rest.ResponseWriter, r *res
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (d *DevAuthApiHandlers) GetLimit(w rest.ResponseWriter, r *rest.Request) {
+	ctx := r.Context()
+
+	l := log.FromContext(ctx)
+
+	name := r.PathParam("name")
+
+	if !model.IsValidLimit(name) {
+		rest_utils.RestErrWithLog(w, r, l,
+			errors.Errorf("unsupported limit %v", name),
+			http.StatusBadRequest)
+		return
+	}
+
+	lim, err := d.devAuth.GetLimit(ctx, name)
+	if err != nil {
+		rest_utils.RestErrWithLogInternal(w, r, l, err)
+		return
+	}
+
+	w.WriteJson(lim)
 }
 
 // Validate status.

--- a/api/http/api_devauth_test.go
+++ b/api/http/api_devauth_test.go
@@ -798,3 +798,73 @@ func TestApiDevAuthPutTenantLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestApiDevAuthGetLimit(t *testing.T) {
+	t.Parallel()
+
+	// enforce specific field naming in errors returned by API
+	updateRestErrorFieldName()
+
+	tcases := []struct {
+		limit string
+
+		daLimit *model.Limit
+		daErr   error
+
+		code int
+		body string
+	}{
+		{
+			limit: "max_devices",
+
+			daLimit: &model.Limit{
+				Name:  model.LimitMaxDeviceCount,
+				Value: 123,
+			},
+			daErr: nil,
+
+			code: http.StatusOK,
+			body: string(asJSON(
+				model.Limit{
+					Name:  model.LimitMaxDeviceCount,
+					Value: 123,
+				},
+			)),
+		},
+		{
+			limit: "bogus",
+
+			code: http.StatusBadRequest,
+			body: RestError("unsupported limit bogus"),
+		},
+		{
+			limit: "max_devices",
+
+			daLimit: nil,
+			daErr:   errors.New("generic error"),
+
+			code: http.StatusInternalServerError,
+			body: RestError("internal error"),
+		},
+	}
+
+	for i := range tcases {
+		tc := tcases[i]
+		t.Run(fmt.Sprintf("tc %d", i), func(t *testing.T) {
+			t.Parallel()
+
+			req := test.MakeSimpleRequest("GET",
+				"http://1.2.3.4/api/management/v1/devauth/limits/"+tc.limit,
+				nil)
+
+			da := &mocks.App{}
+			da.On("GetLimit",
+				context.Background(),
+				tc.limit).
+				Return(tc.daLimit, tc.daErr)
+
+			apih := makeMockApiHandler(t, da)
+			runTestRequest(t, apih, req, tc.code, tc.body)
+		})
+	}
+}

--- a/api/http/api_devauth_test.go
+++ b/api/http/api_devauth_test.go
@@ -740,7 +740,7 @@ func TestApiDevAuthPutTenantLimit(t *testing.T) {
 	}{
 		{
 			req: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/internal/v1/devauth/tenant/foo/limits/max-device-count",
+				"http://1.2.3.4/api/internal/v1/devauth/tenant/foo/limits/max_devices",
 				map[string]int{
 					"limit": 123,
 				}),
@@ -753,7 +753,7 @@ func TestApiDevAuthPutTenantLimit(t *testing.T) {
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/internal/v1/devauth/tenant/foo/limits/max-device-count",
+				"http://1.2.3.4/api/internal/v1/devauth/tenant/foo/limits/max_devices",
 				[]string{"garbage"}),
 			code: http.StatusBadRequest,
 			body: RestError("failed to decode limit request: json: cannot unmarshal array into Go value of type http.LimitValue"),
@@ -769,7 +769,7 @@ func TestApiDevAuthPutTenantLimit(t *testing.T) {
 		},
 		{
 			req: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/internal/v1/devauth/tenant/foo/limits/max-device-count",
+				"http://1.2.3.4/api/internal/v1/devauth/tenant/foo/limits/max_devices",
 				map[string]int{
 					"limit": 123,
 				}),

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -72,6 +72,8 @@ type App interface {
 	VerifyToken(ctx context.Context, token string) error
 
 	SetTenantLimit(ctx context.Context, tenant_id string, limit model.Limit) error
+
+	GetLimit(ctx context.Context, name string) (*model.Limit, error)
 }
 
 type DevAuth struct {
@@ -571,6 +573,19 @@ func (d *DevAuth) VerifyToken(ctx context.Context, raw string) error {
 	}
 
 	return nil
+}
+
+func (d *DevAuth) GetLimit(ctx context.Context, name string) (*model.Limit, error) {
+	lim, err := d.db.GetLimit(ctx, name)
+
+	switch err {
+	case nil:
+		return lim, nil
+	case store.ErrLimitNotFound:
+		return &model.Limit{Name: name, Value: 0}, nil
+	default:
+		return nil, err
+	}
 }
 
 // WithTenantVerification will force verification of tenant token with tenant

--- a/devauth/mocks/App.go
+++ b/devauth/mocks/App.go
@@ -120,6 +120,29 @@ func (_m *App) GetDevices(ctx context.Context, skip uint, limit uint) ([]model.D
 	return r0, r1
 }
 
+// GetLimit provides a mock function with given fields: ctx, name
+func (_m *App) GetLimit(ctx context.Context, name string) (*model.Limit, error) {
+	ret := _m.Called(ctx, name)
+
+	var r0 *model.Limit
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.Limit); ok {
+		r0 = rf(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Limit)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RejectDeviceAuth provides a mock function with given fields: ctx, dev_id, auth_id
 func (_m *App) RejectDeviceAuth(ctx context.Context, dev_id string, auth_id string) error {
 	ret := _m.Called(ctx, dev_id, auth_id)

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -38,7 +38,7 @@ paths:
             description: Unexpected error.
             schema:
               $ref: '#/definitions/Error'
-  /tenant/{tenant_id}/limits/max-device-count:
+  /tenant/{tenant_id}/limits/max_devices:
     get:
       summary: Max device count limit
       parameters:

--- a/model/limit.go
+++ b/model/limit.go
@@ -14,7 +14,11 @@
 package model
 
 const (
-	LimitMaxDeviceCount = "max_device_count"
+	LimitMaxDeviceCount = "max_devices"
+)
+
+var (
+	ValidLimits = []string{LimitMaxDeviceCount}
 )
 
 type Limit struct {
@@ -24,4 +28,13 @@ type Limit struct {
 
 func (l Limit) IsLess(what uint64) bool {
 	return what < l.Value
+}
+
+func IsValidLimit(name string) bool {
+	for _, n := range ValidLimits {
+		if name == n {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
issues: https://tracker.mender.io/browse/MEN-1423

the first 3 commits actually unify the name of the `max_devices` param across the codebase.

@maciejmrowiec @mendersoftware/rndity 