### PR TITLE
GET /devices/count?status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ services:
     - docker
     - mongodb
 
+addons:
+  apt:
+    sources:
+      - mongodb-3.4-precise
+    packages:
+      - mongodb-org-server
+
 # Golang version matrix
 go:
     - 1.8

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -75,6 +75,8 @@ type App interface {
 
 	GetLimit(ctx context.Context, name string) (*model.Limit, error)
 	GetTenantLimit(ctx context.Context, name, tenant_id string) (*model.Limit, error)
+
+	GetDevCountByStatus(ctx context.Context, status string) (int, error)
 }
 
 type DevAuth struct {
@@ -627,4 +629,8 @@ func (d *DevAuth) SetTenantLimit(ctx context.Context, tenant_id string, limit mo
 			limit, tenant_id)
 	}
 	return nil
+}
+
+func (d *DevAuth) GetDevCountByStatus(ctx context.Context, status string) (int, error) {
+	return d.db.GetDevCountByStatus(ctx, status)
 }

--- a/devauth/mocks/App.go
+++ b/devauth/mocks/App.go
@@ -51,6 +51,27 @@ func (_m *App) DecommissionDevice(ctx context.Context, dev_id string) error {
 	return r0
 }
 
+// GetDevCountByStatus provides a mock function with given fields: ctx, status
+func (_m *App) GetDevCountByStatus(ctx context.Context, status string) (int, error) {
+	ret := _m.Called(ctx, status)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = rf(ctx, status)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, status)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetDevice provides a mock function with given fields: ctx, dev_id
 func (_m *App) GetDevice(ctx context.Context, dev_id string) (*model.Device, error) {
 	ret := _m.Called(ctx, dev_id)

--- a/model/count.go
+++ b/model/count.go
@@ -1,0 +1,18 @@
+// Copyright 2017 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package model
+
+type Count struct {
+	Count int `json:"count"`
+}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -86,4 +86,8 @@ type DataStore interface {
 
 	// fetch limit information from data store
 	GetLimit(ctx context.Context, name string) (*model.Limit, error)
+
+	// get the number of devices with a given admission status
+	// computed based on aggregated auth set statuses
+	GetDevCountByStatus(ctx context.Context, status string) (int, error)
 }

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -190,6 +190,27 @@ func (_m *DataStore) GetAuthSetsForDevice(ctx context.Context, devid string) ([]
 	return r0, r1
 }
 
+// GetDevCountByStatus provides a mock function with given fields: ctx, status
+func (_m *DataStore) GetDevCountByStatus(ctx context.Context, status string) (int, error) {
+	ret := _m.Called(ctx, status)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, string) int); ok {
+		r0 = rf(ctx, status)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, status)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetDeviceById provides a mock function with given fields: ctx, id
 func (_m *DataStore) GetDeviceById(ctx context.Context, id string) (*model.Device, error) {
 	ret := _m.Called(ctx, id)


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-1484

involves a pretty horrific mongo aggregation pipeline (to count devices by status), so take a good look.
can filter by status in general, not only 'accepted' devices. this required more work but thought it would be useful to handle this once and for all and not go back to it. other statuses might still be relevant e.g. for the ui in the future.

also, had to bump mongo version on travis to 3.4. we're still stuck at 3.2 (which imo should be fixed across the board). I got bitten by an incompatibility - the `$count` aggregate operator is available since 3.4, hence the fix.

@maciejmrowiec @mendersoftware/rndity 