### PR TITLE
tests/acceptance: test /tenant/{tenant_id}/limits/max_devices endpoint

### DIFF
--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -38,13 +38,12 @@ class BaseDevicesApiClient(BaseApiClient):
     api_url = "http://%s/api/devices/v1/authentication/" % \
               pytest.config.getoption("host")
 
-
 class SwaggerApiClient(BaseApiClient):
     config = {
         'also_return_response': True,
         'validate_responses': True,
         'validate_requests': False,
-        'validate_swagger_spec': False,
+        'validate_swagger_spec': True,
         'use_models': True,
     }
 
@@ -68,6 +67,18 @@ class InternalClient(SwaggerApiClient):
 
     log = logging.getLogger('client.InternalClient')
 
+    spec_option = 'spec'
+
+    def setup(self):
+        self.setup_swagger()
+
+    def get_max_devices_limit(self, tenant_id):
+        return self.client.tenant.get_tenant_tenant_id_limits_max_devices(tenant_id=tenant_id).result()[0]
+
+    def put_max_devices_limit(self, tenant_id, limit):
+        Limit = self.client.get_model('Limit')
+        l = Limit(limit=limit)
+        return self.client.tenant.put_tenant_tenant_id_limits_max_devices(tenant_id=tenant_id, limit=l)
 
 class SimpleInternalClient(InternalClient):
     """Internal API client. Cannot be used as pytest base class"""

--- a/tests/tests/test_limits.py
+++ b/tests/tests/test_limits.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+import bravado
+import pytest
+import bravado_core
+
+from client import InternalClient, SimpleInternalClient
+import mockserver
+
+class TestLimits(InternalClient):
+
+    def test_get_limit_default_limit(self):
+        limit = self.get_max_devices_limit('foo')
+        assert limit.limit == 0
+
+    def test_put_limit(self):
+        max_devs = 100
+        _, http_rsp = self.put_max_devices_limit('foo', max_devs).result()
+        assert isinstance(http_rsp, bravado_core.response.IncomingResponse)
+        assert http_rsp.status_code == 204
+
+    def test_limit(self):
+        max_devs = 10
+        _, http_rsp = self.put_max_devices_limit('foo', max_devs).result()
+        assert isinstance(http_rsp, bravado_core.response.IncomingResponse)
+        assert http_rsp.status_code == 204
+
+        limit = self.get_max_devices_limit('foo')
+        assert limit.limit == max_devs
+
+    def test_limit_differnt_tenants(self):
+        max_devs = 10
+        _, http_rsp = self.put_max_devices_limit('foo', max_devs).result()
+        assert isinstance(http_rsp, bravado_core.response.IncomingResponse)
+        assert http_rsp.status_code == 204
+
+        limit = self.get_max_devices_limit('bar')
+        assert limit.limit == 0
+
+    def test_put_limit_malformed_limit(self):
+        try:
+            _, http_rsp = self.put_max_devices_limit('foo', '1').result()
+        except bravado.exception.HTTPError as herr:
+            assert herr.response.status_code == 400
+        else:
+            assert isinstance(http_rsp, bravado_core.response.IncomingResponse)
+            pytest.fail("Expected Bad Request (400), got: %d" %(http_rsp.status_code,))


### PR DESCRIPTION
- /tenant/{tenant_id}/limits/max_devices endpoint tests (GET and PUT methods)
- swagger spec validation enabled

@maciejmrowiec @mendersoftware/rndity 