### PR TITLE
enforce device count limit

### DIFF
--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -351,6 +351,9 @@ func (d *DevAuthApiHandlers) UpdateDeviceStatusHandler(w rest.ResponseWriter, r 
 			rest_utils.RestErrWithLog(w, r, l, err, http.StatusNotFound)
 		case devauth.ErrDevIdAuthIdMismatch:
 			rest_utils.RestErrWithLog(w, r, l, err, http.StatusBadRequest)
+		case devauth.ErrMaxDeviceCountReached:
+			rest_utils.RestErrWithLog(w, r, l, err, http.StatusUnprocessableEntity)
+
 		default:
 			rest_utils.RestErrWithLogInternal(w, r, l, err)
 		}

--- a/api/http/api_devauth_test.go
+++ b/api/http/api_devauth_test.go
@@ -290,6 +290,15 @@ func TestApiDevAuthUpdateStatusDevice(t *testing.T) {
 			dev: nil,
 			err: errors.New("processing failed"),
 		},
+		"567,890": {
+			dev: &model.Device{
+				Id:     "foo",
+				PubKey: "foobar",
+				Status: "pending",
+				IdData: "deadcafe",
+			},
+			err: devauth.ErrMaxDeviceCountReached,
+		},
 	}
 
 	mockaction := func(_ context.Context, dev_id string, auth_id string) error {
@@ -380,6 +389,13 @@ func TestApiDevAuthUpdateStatusDevice(t *testing.T) {
 				penstatus),
 			code: http.StatusBadRequest,
 			body: RestError("dev auth: dev ID and auth ID mismatch"),
+		},
+		{
+			req: test.MakeSimpleRequest("PUT",
+				"http://1.2.3.4/api/management/v1/devauth/devices/567/auth/890/status",
+				accstatus),
+			code: http.StatusUnprocessableEntity,
+			body: RestError("maximum number of accepted devices reached"),
 		},
 	}
 

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -152,6 +152,10 @@ paths:
           description: The device was not found.
           schema:
             $ref: "#/definitions/Error"
+        422:
+          description: Request cannot be fulfilled e.g. due to exceeded limit on maximum accepted devices (see error message).
+          schema:
+            $ref: "#/definitions/Error"
         500:
           description: Internal server error.
           schema:

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -85,8 +85,7 @@ class InternalClient(SwaggerApiClient):
     def put_max_devices_limit(self, tenant_id, limit):
         Limit = self.client.get_model('Limit')
         l = Limit(limit=limit)
-        return self.client.tenant.put_tenant_tenant_id_limits_max_devices(tenant_id=tenant_id,
-                                                                          limit=l).result()
+        return self.client.tenant.put_tenant_tenant_id_limits_max_devices(tenant_id=tenant_id, limit=l).result()[0]
 
 class SimpleInternalClient(InternalClient):
     """Internal API client. Cannot be used as pytest base class"""

--- a/tests/tests/test_device.py
+++ b/tests/tests/test_device.py
@@ -141,7 +141,6 @@ class TestDevice:
         print('limit:', limit)
         assert limit.limit == 0
 
-    @pytest.mark.xfail(reason='Not implemented yed, waiting for MEN-1486')
     @pytest.mark.parametrize('tenant_foobar_devices', ['5'], indirect=True)
     def test_device_limit_applied(self, management_api, internal_api,
                                   tenant_foobar_devices, tenant_foobar):


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-1486

this is part 1 of the work. next PR will go into `deviceadm` (propagate the new 422 status to the user when accepting a device, with the exact same message).

@maciejmrowiec @mendersoftware/rndity 
