### PR TITLE
correctly set content-type of JWT auth token

### DIFF
--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -155,8 +155,9 @@ func (d *DevAuthApiHandlers) SubmitAuthRequestHandler(w rest.ResponseWriter, r *
 			http.StatusUnauthorized, "unauthorized")
 		return
 	case nil:
-		w.(http.ResponseWriter).Header().Set("Content-Type", "application/jwt")
-		w.(http.ResponseWriter).Write([]byte(token))
+		ww := w.(http.ResponseWriter)
+		ww.Header().Set("Content-Type", "application/jwt")
+		ww.Write([]byte(token))
 		return
 	default:
 		rest_utils.RestErrWithLogInternal(w, r, l, err)

--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -155,8 +155,8 @@ func (d *DevAuthApiHandlers) SubmitAuthRequestHandler(w rest.ResponseWriter, r *
 			http.StatusUnauthorized, "unauthorized")
 		return
 	case nil:
+		w.(http.ResponseWriter).Header().Set("Content-Type", "application/jwt")
 		w.(http.ResponseWriter).Write([]byte(token))
-		w.Header().Set("Content-Type", "application/jwt")
 		return
 	default:
 		rest_utils.RestErrWithLogInternal(w, r, l, err)

--- a/tests/tests/test_token.py
+++ b/tests/tests/test_token.py
@@ -96,7 +96,6 @@ class TestToken:
                             headers={'Authorization': auth_hdr})
 
         assert rsp.status_code == 200
-        print rsp.headers
         assert rsp.headers['Content-Type'] == "application/jwt"
 
     def test_token_verify_none(self, token_verify_url):

--- a/tests/tests/test_token.py
+++ b/tests/tests/test_token.py
@@ -94,7 +94,9 @@ class TestToken:
         # successful verification
         rsp = requests.post(token_verify_url, data='',
                             headers={'Authorization': auth_hdr})
+
         assert rsp.status_code == 200
+        print rsp.headers
         assert rsp.headers['Content-Type'] == "application/jwt"
 
     def test_token_verify_none(self, token_verify_url):

--- a/tests/tests/test_token.py
+++ b/tests/tests/test_token.py
@@ -95,6 +95,7 @@ class TestToken:
         rsp = requests.post(token_verify_url, data='',
                             headers={'Authorization': auth_hdr})
         assert rsp.status_code == 200
+        assert rsp.headers['Content-Type'] == "application/jwt"
 
     def test_token_verify_none(self, token_verify_url):
         # no auth header should raise an error


### PR DESCRIPTION
Noticed that the token response headers are incorrect this weekend while investigating something else.
The response content-type is "application/json" but the response is not valid JSON  

@bboozzoo @maciejmrowiec 