### PR TITLE
devauth: fix preauth case handling in POST /auth_requests 

### DIFF
--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -312,7 +312,6 @@ func (d *DevAuth) processPreAuthRequest(ctx context.Context, r *model.AuthReq) (
 	}
 
 	// persist the 'accepted' status in both auth set, and device
-	aset.Status = model.DevStatusAccepted
 	if err := d.db.UpdateAuthSet(ctx, aset, model.AuthSetUpdate{
 		Status: model.DevStatusAccepted,
 	}); err != nil {
@@ -329,6 +328,7 @@ func (d *DevAuth) processPreAuthRequest(ctx context.Context, r *model.AuthReq) (
 		return nil, errors.Wrap(err, "failed to update auth set status")
 	}
 
+	aset.Status = model.DevStatusAccepted
 	return aset, nil
 }
 


### PR DESCRIPTION
set the 'accepted' status just before returning to the main routine -
but not before, the struct is being used to match a 'preauthorized' entry
in the db ('accepted' will never match).

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>


@mendersoftware/rndity @maciejmrowiec 