### PR TITLE
fix: Deleting AuthSets and Tokens uses single item delete call  

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -520,14 +520,14 @@ func (db *DataStoreMongo) DeleteAuthSetsForDevice(ctx context.Context, devid str
 
 	c := s.DB(ctxstore.DbFromContext(ctx, DbName)).C(DbAuthSetColl)
 
-	err := c.Remove(model.AuthSet{DeviceId: devid})
+	ci, err := c.RemoveAll(model.AuthSet{DeviceId: devid})
+
+	if ci.Removed == 0 {
+		return store.ErrAuthSetNotFound
+	}
 
 	if err != nil {
-		if err == mgo.ErrNotFound {
-			return store.ErrAuthSetNotFound
-		} else {
-			return errors.Wrap(err, "failed to remove auth sets for device")
-		}
+		return errors.Wrap(err, "failed to remove auth sets for device")
 	}
 
 	return nil

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -316,14 +316,14 @@ func (db *DataStoreMongo) DeleteTokenByDevId(ctx context.Context, devId string) 
 	defer s.Close()
 
 	c := db.session.DB(ctxstore.DbFromContext(ctx, DbName)).C(DbTokensColl)
-	err := c.Remove(bson.M{"dev_id": devId})
+	ci, err := c.RemoveAll(bson.M{"dev_id": devId})
+
+	if ci.Removed == 0 {
+		return store.ErrTokenNotFound
+	}
 
 	if err != nil {
-		if err == mgo.ErrNotFound {
-			return store.ErrTokenNotFound
-		} else {
-			return errors.Wrap(err, "failed to remove token")
-		}
+		return errors.Wrap(err, "failed to remove tokens")
 	}
 
 	return nil


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-1752

@mendersoftware/rndity @maciejmrowiec 