### PR TITLE
Revert "travis: update from Go 1.8 to 1.10"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 
 # Golang version matrix
 go:
-    - 1.10
+    - 1.8
 
 env:
     matrix:


### PR DESCRIPTION
This reverts commit 304fbe7daa4bd1ed610a193e52d6c3c0afa01bb7.