### PR TITLE
count devices with 'preauthorized' status

### DIFF
--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -250,9 +250,10 @@ func (d *DevAuthApiHandlers) GetDevicesCountHandler(w rest.ResponseWriter, r *re
 	case model.DevStatusAccepted,
 		model.DevStatusRejected,
 		model.DevStatusPending,
+		model.DevStatusPreauth,
 		"":
 	default:
-		rest_utils.RestErrWithLog(w, r, l, errors.New("status must be one of: pending, accepted, rejected"), http.StatusBadRequest)
+		rest_utils.RestErrWithLog(w, r, l, errors.New("status must be one of: pending, accepted, rejected, preauthorized"), http.StatusBadRequest)
 		return
 	}
 

--- a/api/http/api_devauth_test.go
+++ b/api/http/api_devauth_test.go
@@ -1148,6 +1148,19 @@ func TestApiDevAuthGetDevicesCount(t *testing.T) {
 			)),
 		},
 		{
+			status: model.DevStatusPreauth,
+
+			daCnt: 7,
+			daErr: nil,
+
+			code: http.StatusOK,
+			body: string(asJSON(
+				model.Count{
+					Count: 7,
+				},
+			)),
+		},
+		{
 			status: "",
 
 			daCnt: 10,
@@ -1164,7 +1177,7 @@ func TestApiDevAuthGetDevicesCount(t *testing.T) {
 			status: "bogus",
 
 			code: http.StatusBadRequest,
-			body: RestError("status must be one of: pending, accepted, rejected"),
+			body: RestError("status must be one of: pending, accepted, rejected, preauthorized"),
 		},
 		{
 			status: "accepted",


### PR DESCRIPTION
With this PR it should be possible to use devices/count endpoint to count devices with status 'preauthorized':
GET devauth/devices/count?status=preauthorized

Issues: https://tracker.mender.io/browse/MEN-1884