### PR TITLE
id data and public key normalization in admission preauth api  

### DIFF
--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -746,6 +746,7 @@ func (d *DevAuthApiHandlers) DevAdmPostDevicesHandler(w rest.ResponseWriter, r *
 		return
 	}
 	// translate to devauth object
+	// id data is already sorted/normalized in ParseDevAdmAuthReqSet
 	req := &model.PreAuthReq{
 		DeviceId:  bson.NewObjectId().Hex(),
 		AuthSetId: bson.NewObjectId().Hex(),

--- a/api/http/api_devauth_test.go
+++ b/api/http/api_devauth_test.go
@@ -2155,6 +2155,17 @@ func ExtractHeader(hdr, val string, r *test.Recorded) string {
 }
 
 func TestApiDevAuthDevAdmPostDeviceAuth(t *testing.T) {
+	validKey := `
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzogVU7RGDilbsoUt/DdH
+VJvcepl0A5+xzGQ50cq1VE/Dyyy8Zp0jzRXCnnu9nu395mAFSZGotZVr+sWEpO3c
+yC3VmXdBZmXmQdZqbdD/GuixJOYfqta2ytbIUPRXFN7/I7sgzxnXWBYXYmObYvdP
+okP0mQanY+WKxp7Q16pt1RoqoAd0kmV39g13rFl35muSHbSBoAW3GBF3gO+mF5Ty
+1ddp/XcgLOsmvNNjY+2HOD5F/RX0fs07mWnbD7x+xz7KEKjF+H7ZpkqCwmwCXaf0
+iyYyh1852rti3Afw4mDxuVSD7sd9ggvYMc0QHIpQNkD4YWOhNiE1AB0zH57VbUYG
+UwIDAQAB
+-----END PUBLIC KEY-----`
+
 	testCases := map[string]struct {
 		body interface{}
 
@@ -2163,7 +2174,7 @@ func TestApiDevAuthDevAdmPostDeviceAuth(t *testing.T) {
 		checker mt.ResponseChecker
 	}{
 		"ok": {
-			body: &model.DevAdmAuthSetReq{Key: "foo-key", DeviceId: toJsonString(t,
+			body: &model.DevAdmAuthSetReq{Key: validKey, DeviceId: toJsonString(t,
 				map[string]string{
 					"mac": "00:00:00:01",
 				}),
@@ -2173,6 +2184,17 @@ func TestApiDevAuthDevAdmPostDeviceAuth(t *testing.T) {
 				nil,
 				nil),
 		},
+		"error, invalid key": {
+			body: &model.DevAdmAuthSetReq{Key: "foo", DeviceId: toJsonString(t,
+				map[string]string{
+					"mac": "00:00:00:01",
+				}),
+			},
+			checker: mt.NewJSONResponse(
+				http.StatusBadRequest,
+				nil,
+				restError("cannot decode public key")),
+		},
 		"error: empty request": {
 			body: nil,
 			checker: mt.NewJSONResponse(
@@ -2181,7 +2203,7 @@ func TestApiDevAuthDevAdmPostDeviceAuth(t *testing.T) {
 				restError("EOF")),
 		},
 		"error: generic": {
-			body: &model.DevAdmAuthSetReq{Key: "foo-key", DeviceId: toJsonString(t,
+			body: &model.DevAdmAuthSetReq{Key: validKey, DeviceId: toJsonString(t,
 				map[string]string{
 					"mac": "00:00:00:01",
 				})},
@@ -2202,14 +2224,14 @@ func TestApiDevAuthDevAdmPostDeviceAuth(t *testing.T) {
 				restError("key: non zero value required")),
 		},
 		"error: no identity data": {
-			body: &model.DevAdmAuthSetReq{Key: "foo-key"},
+			body: &model.DevAdmAuthSetReq{Key: validKey},
 			checker: mt.NewJSONResponse(
 				http.StatusBadRequest,
 				nil,
 				restError("device_identity: non zero value required")),
 		},
 		"error: conflict": {
-			body: &model.DevAdmAuthSetReq{Key: "foo-key", DeviceId: toJsonString(t,
+			body: &model.DevAdmAuthSetReq{Key: validKey, DeviceId: toJsonString(t,
 				map[string]string{
 					"mac": "00:00:00:01",
 				})},

--- a/api/http/api_devauth_test.go
+++ b/api/http/api_devauth_test.go
@@ -2230,6 +2230,13 @@ UwIDAQAB
 				nil,
 				restError("device_identity: non zero value required")),
 		},
+		"error: invalid id data": {
+			body: &model.DevAdmAuthSetReq{Key: validKey, DeviceId: "{mac: 1234}"},
+			checker: mt.NewJSONResponse(
+				http.StatusBadRequest,
+				nil,
+				restError("failed to decode attributes data: invalid character 'm' looking for beginning of object key string")),
+		},
 		"error: conflict": {
 			body: &model.DevAdmAuthSetReq{Key: validKey, DeviceId: toJsonString(t,
 				map[string]string{

--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -1683,7 +1683,7 @@ func TestDevAuthProvisionTenant(t *testing.T) {
 			db := mstore.DataStore{}
 			db.On("MigrateTenant", ctx,
 				mock.AnythingOfType("string"),
-				"1.2.0",
+				"1.3.0",
 			).Return(tc.datastoreError)
 			db.On("WithAutomigrate").Return(&db)
 			devauth := NewDevAuth(&db, nil, nil, Config{})

--- a/model/devadm-authset-req.go
+++ b/model/devadm-authset-req.go
@@ -73,6 +73,14 @@ func ParseDevAdmAuthSetReq(source io.Reader) (*DevAdmAuthSetReq, error) {
 		return nil, errors.New("no attributes provided")
 	}
 
+	// validate/normalize id data
+	// enough to re-encode via stdlib to get alphabetical key sort
+	if sorted, err := json.Marshal(req.Attributes); err != nil {
+		return nil, err
+	} else {
+		req.DeviceId = string(sorted)
+	}
+
 	return &req, nil
 }
 

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	DbVersion     = "1.2.0"
+	DbVersion     = "1.3.0"
 	DbName        = "deviceauth"
 	DbDevicesColl = "devices"
 	DbAuthSetColl = "auth_sets"
@@ -405,6 +405,10 @@ func (db *DataStoreMongo) MigrateTenant(ctx context.Context, database, version s
 			ctx: ctx,
 		},
 		&migration_1_2_0{
+			ms:  db,
+			ctx: ctx,
+		},
+		&migration_1_3_0{
 			ms:  db,
 			ctx: ctx,
 		},

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -719,7 +719,7 @@ func TestStoreMigrate(t *testing.T) {
 		DbVersion + " no automigrate": {
 			automigrate: false,
 			version:     DbVersion,
-			err:         "failed to apply migrations: db needs migration: deviceauth has version 0.0.0, needs version 1.2.0",
+			err:         "failed to apply migrations: db needs migration: deviceauth has version 0.0.0, needs version 1.3.0",
 		},
 		DbVersion + " multitenant": {
 			automigrate: true,
@@ -731,7 +731,7 @@ func TestStoreMigrate(t *testing.T) {
 			automigrate: false,
 			tenantDbs:   []string{"deviceauth-tenant1id", "deviceauth-tenant2id"},
 			version:     DbVersion,
-			err:         "failed to apply migrations: db needs migration: deviceauth-tenant1id has version 0.0.0, needs version 1.2.0",
+			err:         "failed to apply migrations: db needs migration: deviceauth-tenant1id has version 0.0.0, needs version 1.3.0",
 		},
 		"0.1 error": {
 			automigrate: true,

--- a/store/mongo/migration_1_3_0.go
+++ b/store/mongo/migration_1_3_0.go
@@ -1,0 +1,116 @@
+// Copyright 2018 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	"crypto/rsa"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	ctxstore "github.com/mendersoftware/go-lib-micro/store"
+	"github.com/pkg/errors"
+
+	"github.com/mendersoftware/deviceauth/model"
+	"github.com/mendersoftware/deviceauth/utils"
+)
+
+type migration_1_3_0 struct {
+	ms  *DataStoreMongo
+	ctx context.Context
+}
+
+func (m *migration_1_3_0) Up(from migrate.Version) error {
+	s := m.ms.session.Copy()
+
+	defer s.Close()
+
+	iter := s.DB(ctxstore.DbFromContext(m.ctx, DbName)).
+		C(DbAuthSetColl).Find(nil).Iter()
+
+	var set model.AuthSet
+
+	for iter.Next(&set) {
+		newKey, err := normalizeKey(set.PubKey)
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to normalize key of auth set %v: %v", set.Id, set.PubKey)
+		}
+
+		update := model.AuthSetUpdate{
+			PubKey: newKey,
+		}
+
+		if err := s.DB(ctxstore.DbFromContext(m.ctx, DbName)).
+			C(DbAuthSetColl).UpdateId(set.Id, update); err != nil {
+			return errors.Wrapf(err, "failed to update auth set %v", set.Id)
+		}
+
+	}
+
+	if err := iter.Close(); err != nil {
+		return errors.Wrap(err, "failed to close DB iterator")
+	}
+
+	iter = s.DB(ctxstore.DbFromContext(m.ctx, DbName)).
+		C(DbDevicesColl).Find(nil).Iter()
+
+	var dev model.Device
+
+	for iter.Next(&dev) {
+		newKey, err := normalizeKey(dev.PubKey)
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to normalize key of device %v: %v", dev.Id, dev.PubKey)
+		}
+
+		update := model.DeviceUpdate{
+			PubKey: newKey,
+		}
+
+		if err := s.DB(ctxstore.DbFromContext(m.ctx, DbName)).
+			C(DbDevicesColl).UpdateId(dev.Id, update); err != nil {
+			return errors.Wrapf(err, "failed to update device %v", dev.Id)
+		}
+
+	}
+
+	if err := iter.Close(); err != nil {
+		return errors.Wrap(err, "failed to close DB iterator")
+	}
+
+	return nil
+}
+
+func (m *migration_1_3_0) Version() migrate.Version {
+	return migrate.MakeVersion(1, 3, 0)
+}
+
+func normalizeKey(key string) (string, error) {
+	parsed, err := utils.ParsePubKey(key)
+	if err != nil {
+		return "", err
+	}
+
+	keyStruct, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		return "", errors.New("cannot decode public key")
+	}
+
+	serialized, err := utils.SerializePubKey(keyStruct)
+	if err != nil {
+		return "", err
+	}
+
+	return serialized, nil
+}

--- a/store/mongo/migration_1_3_0_test.go
+++ b/store/mongo/migration_1_3_0_test.go
@@ -1,0 +1,181 @@
+// Copyright 2018 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/mendersoftware/go-lib-micro/identity"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	ctxstore "github.com/mendersoftware/go-lib-micro/store"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mendersoftware/deviceauth/model"
+	"github.com/mendersoftware/deviceauth/utils"
+)
+
+func TestMigration_1_3_0(t *testing.T) {
+	goodKey := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzogVU7RGDilbsoUt/DdH
+VJvcepl0A5+xzGQ50cq1VE/Dyyy8Zp0jzRXCnnu9nu395mAFSZGotZVr+sWEpO3c
+yC3VmXdBZmXmQdZqbdD/GuixJOYfqta2ytbIUPRXFN7/I7sgzxnXWBYXYmObYvdP
+okP0mQanY+WKxp7Q16pt1RoqoAd0kmV39g13rFl35muSHbSBoAW3GBF3gO+mF5Ty
+1ddp/XcgLOsmvNNjY+2HOD5F/RX0fs07mWnbD7x+xz7KEKjF+H7ZpkqCwmwCXaf0
+iyYyh1852rti3Afw4mDxuVSD7sd9ggvYMc0QHIpQNkD4YWOhNiE1AB0zH57VbUYG
+UwIDAQAB
+-----END PUBLIC KEY-----`
+
+	badKey := `iyYyh1852rb`
+
+	cases := map[string]struct {
+		sets []model.AuthSet
+		devs []model.Device
+
+		err error
+	}{
+		"ok": {
+			devs: []model.Device{
+				{
+					Id:     "1",
+					IdData: "{\"sn\":\"0001\"}",
+					PubKey: goodKey,
+				},
+			},
+
+			sets: []model.AuthSet{
+				{
+					Id:       "1",
+					DeviceId: "1",
+					IdData:   "{\"sn\":\"0001\"}",
+					PubKey:   goodKey,
+				},
+			},
+		},
+		"error, authset": {
+			sets: []model.AuthSet{
+				{
+					Id:       "1",
+					DeviceId: "1",
+					IdData:   "{\"sn\":\"0001\"}",
+					PubKey:   badKey,
+				},
+			},
+			err: errors.New("failed to normalize key of auth set 1: iyYyh1852rb: cannot decode public key"),
+		},
+		"error, device": {
+			devs: []model.Device{
+				{
+					Id:     "1",
+					IdData: "{\"sn\":\"0001\"}",
+					PubKey: badKey,
+				},
+			},
+			err: errors.New("failed to normalize key of device 1: iyYyh1852rb: cannot decode public key"),
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(fmt.Sprintf("tc %s", n), func(t *testing.T) {
+			ctx := identity.WithContext(context.Background(), &identity.Identity{
+				Tenant: "foo",
+			})
+
+			db.Wipe()
+			db := NewDataStoreMongoWithSession(db.Session())
+			defer db.session.Close()
+
+			prep_1_2_0(t, ctx, db)
+
+			for _, d := range tc.devs {
+				err := db.AddDevice(ctx, d)
+				assert.NoError(t, err)
+			}
+
+			for _, a := range tc.sets {
+				err := db.AddAuthSet(ctx, a)
+				assert.NoError(t, err)
+			}
+
+			mig130 := migration_1_3_0{
+				ms:  db,
+				ctx: ctx,
+			}
+
+			err := mig130.Up(migrate.MakeVersion(1, 2, 0))
+
+			if tc.err == nil {
+				assert.NoError(t, err)
+				verify(t, ctx, db)
+			} else {
+				assert.EqualError(t, tc.err, err.Error())
+			}
+		})
+	}
+}
+
+func prep_1_2_0(t *testing.T, ctx context.Context, db *DataStoreMongo) {
+	migrations := []migrate.Migration{
+		&migration_1_1_0{
+			ms:  db,
+			ctx: ctx,
+		},
+		&migration_1_2_0{
+			ms:  db,
+			ctx: ctx,
+		},
+	}
+
+	last := migrate.MakeVersion(0, 1, 0)
+	for _, m := range migrations {
+		err := m.Up(last)
+		assert.NoError(t, err)
+		last = m.Version()
+	}
+}
+
+func verify(t *testing.T, ctx context.Context, db *DataStoreMongo) {
+	s := db.session.Copy()
+
+	defer s.Close()
+
+	iter := s.DB(ctxstore.DbFromContext(ctx, DbName)).
+		C(DbAuthSetColl).Find(nil).Iter()
+
+	var set model.AuthSet
+
+	for iter.Next(&set) {
+		_, err := utils.ParsePubKey(set.PubKey)
+		assert.NoError(t, err)
+	}
+
+	err := iter.Close()
+	assert.NoError(t, err)
+
+	iter = s.DB(ctxstore.DbFromContext(ctx, DbName)).
+		C(DbDevicesColl).Find(nil).Iter()
+
+	var dev model.Device
+
+	for iter.Next(&dev) {
+		_, err := utils.ParsePubKey(dev.PubKey)
+		assert.NoError(t, err)
+	}
+
+	err = iter.Close()
+	assert.NoError(t, err)
+
+}

--- a/tests/tests/test_admission.py
+++ b/tests/tests/test_admission.py
@@ -6,7 +6,9 @@ from common import Device, DevAuthorizer, \
     device_auth_req, make_devices, devices, \
     clean_migrated_db, clean_db, mongo, cli, \
     management_api, admission_api, internal_api, device_api, \
-    tenant_foobar, tenant_foobar_devices, tenant_foobar_clean_migrated_db
+    tenant_foobar, tenant_foobar_devices, tenant_foobar_clean_migrated_db,\
+    get_keypair
+
 from tenantadm import fake_tenantadm
 import orchestrator
 
@@ -69,15 +71,17 @@ class TestAdmissionPostDevicesBase:
     def _test_ok(self, admission_api, clean_migrated_db, auth=None):
         identity = json.dumps({"mac": "new-preauth-mac"})
 
-        admission_api.preauthorize(identity, 'new-preauth-key', auth)
+        _, pub =  get_keypair()
+        admission_api.preauthorize(identity, pub, auth)
 
         asets = admission_api.get_devices(auth=auth)
         assert len(asets) == 1
         assert asets[0].status == 'preauthorized'
 
     def _test_bad_req_iddata(self, admission_api, clean_migrated_db, auth=None):
+        _, pub =  get_keypair()
         try:
-            admission_api.preauthorize('not-valid-json', 'new-preauth-key', auth)
+            admission_api.preauthorize('not-valid-json', pub, auth)
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 400
 
@@ -85,15 +89,28 @@ class TestAdmissionPostDevicesBase:
         assert len(asets) == 0
 
     def _test_conflict(self, admission_api, devices, auth=None):
+        _, pub =  get_keypair()
         for dev, _ in devices:
             try:
                 identity = dev.identity
-                admission_api.preauthorize(identity, 'new-preauth-key', auth)
+                admission_api.preauthorize(identity, pub, auth)
             except bravado.exception.HTTPError as e:
                 assert e.response.status_code == 409
 
         asets = admission_api.get_devices(auth=auth)
         assert len(asets) == len(devices)
+
+    def _test_bad_key(self, admission_api, clean_migrated_db, auth=None):
+        identity = json.dumps({"mac": "new-preauth-mac"})
+
+        try:
+            admission_api.preauthorize(identity, 'invalid', auth)
+        except bravado.exception.HTTPError as e:
+            assert e.response.status_code == 400
+            assert e.response.swagger_result.error == 'cannot decode public key'
+
+        asets = admission_api.get_devices(auth=auth)
+        assert len(asets) == 0
 
 class TestAdmissionPostDevices(TestAdmissionPostDevicesBase):
     def test_ok(self, admission_api, clean_migrated_db):
@@ -105,6 +122,9 @@ class TestAdmissionPostDevices(TestAdmissionPostDevicesBase):
     @pytest.mark.parametrize('devices', ['5'], indirect=True)
     def test_conflict(self, admission_api, devices):
         self._test_conflict(admission_api, devices)
+
+    def test_bad_key(self, admission_api, clean_migrated_db):
+        self._test_bad_key(admission_api, clean_migrated_db)
 
 class TestAdmissionChangeStatus(AdmissionClient):
 
@@ -218,6 +238,10 @@ class TestAdmissionPostDevicesMultitenant(TestAdmissionPostDevicesBase):
     def test_bad_req_iddata(self, admission_api, tenant_foobar_clean_migrated_db, tenant_foobar):
         auth = {"Authorization": "Bearer " + tenant_foobar}
         self._test_bad_req_iddata(admission_api, tenant_foobar_clean_migrated_db, auth)
+
+    def test_bad_key(self, admission_api, tenant_foobar_clean_migrated_db, tenant_foobar):
+        auth = {"Authorization": "Bearer " + tenant_foobar}
+        self._test_bad_key(admission_api, tenant_foobar_clean_migrated_db, auth)
 
     @pytest.mark.parametrize('tenant_foobar_devices', ['5'], indirect=True)
     def test_conflict(self, admission_api, tenant_foobar_devices, tenant_foobar):


### PR DESCRIPTION
by mistake key normalization was introduced to the `deviceadm` service while the devauth-devadm merge was already in progress (in https://github.com/mendersoftware/deviceadm/pull/136).

port these changes to the admission portion of the `devauth` api.

we completely forgot about id data normalization in admission preauth though, so introduce that too (until now only the internal devauth EP had that, and that's useless especially after the services are merged).

Issues: https://tracker.mender.io/browse/MEN-1900, https://tracker.mender.io/browse/MEN-1901