### PR TITLE
docs: management API v2: POST devices/: return conflicting device

### DIFF
--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -95,9 +95,9 @@ paths:
           schema:
             $ref: '#/definitions/Error'
         409:
-          description: Device already exists.
+          description: Device already exists. Response contains conflicting device.
           schema:
-            $ref: '#/definitions/Error'
+            $ref: '#/definitions/Device'
         500:
           description: Unexpected error
           schema:


### PR DESCRIPTION
When there is a conflict while preauthorizing devices, return
conflicting device in 409 Conflict response body.