### PR TITLE
store/mongo: fix migration 1.4.0

### DIFF
--- a/store/mongo/migration_1_4_0.go
+++ b/store/mongo/migration_1_4_0.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mendersoftware/deviceauth/model"
+	"github.com/mendersoftware/deviceauth/store"
 	uto "github.com/mendersoftware/deviceauth/utils/to"
 )
 
@@ -45,7 +46,11 @@ func (m *migration_1_4_0) Up(from migrate.Version) error {
 		status, err := m.ms.GetDeviceStatus(m.ctx, dev.Id)
 
 		if err != nil {
-			return errors.Wrap(err, "Cannot determine device status")
+			if err == store.ErrAuthSetNotFound {
+				status = model.DevStatusRejected
+			} else {
+				return errors.Wrapf(err, "Cannot determine device status for device: %s", dev.Id)
+			}
 		}
 
 		if err := m.ms.UpdateDevice(m.ctx,


### PR DESCRIPTION
Migration 1.4.0 is setting device statuses based on devices
authentication set statuses.
If the device has no authentication sets then set device status to
"rejected" (there is no better status in this case).
