### PR TITLE
travis conf: disable git shallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 # Forces travis to use VM insted container, required to be able to build containers.
 sudo: required
 
+# Disable git shallow clone. We need full history for validating copyright year of each file.
+git:
+    depth: false
+
 services:
     - docker
     - mongodb


### PR DESCRIPTION
Travis is cloning repositories with depth=50 by default.
We need full git history for validating copyright year of each file.