### PR TITLE
Add support for default tenant token.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,20 +123,6 @@ jobs:
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F acceptance ;
 
-    - stage: Tests
-      name: "backend-integration"
-      install:
-        - sudo apt-get -qq update
-        - pip3 install -U --user PyYAML
-      script:
-        - git clone -b master https://github.com/mendersoftware/integration.git;
-
-        - CGO_ENABLED=0 go build;
-        - sudo docker build -t mendersoftware/deviceauth:pr .;
-
-        - ./integration/extra/release_tool.py --set-version-of mender-device-auth --version pr;
-        - PYTEST_ARGS="-k 'not Multitenant'" ./integration/backend-tests/run;
-
     - stage: Trigger integration
       script:
         - echo "TODO trigger jenkins integration tests"

--- a/client/tenant/client_tenantadm.go
+++ b/client/tenant/client_tenantadm.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -35,7 +35,8 @@ const (
 )
 
 const (
-	MsgErrTokenVerificationFailed = "token verification failed"
+	MsgErrTokenVerificationFailed = "tenant token verification failed"
+	MsgErrTokenMissing            = "tenant token missing"
 )
 
 func IsErrTokenVerificationFailed(e error) bool {
@@ -44,6 +45,10 @@ func IsErrTokenVerificationFailed(e error) bool {
 
 func MakeErrTokenVerificationFailed(apiErr error) error {
 	return errors.Wrap(apiErr, MsgErrTokenVerificationFailed)
+}
+
+func IsErrTokenMissing(e error) bool {
+	return strings.HasPrefix(e.Error(), MsgErrTokenMissing)
 }
 
 // ClientConfig conveys client configuration

--- a/client/tenant/client_tenantadm_test.go
+++ b/client/tenant/client_tenantadm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ func TestClient(t *testing.T) {
 		{
 			status: http.StatusUnauthorized,
 			body:   restError("account suspended"),
-			err:    errors.New("token verification failed: account suspended"),
+			err:    errors.New("tenant token verification failed: account suspended"),
 		},
 	}
 

--- a/config.yaml
+++ b/config.yaml
@@ -58,7 +58,7 @@
 # Defaults to: none
 # Overwrite with environment variable: DEVICEAUTH_TENANTADM_ADDR
 
-# device_auth_orchestrator:  http://tenantadm
+# tenantadm_addr:  http://tenantadm
 
 # Private key path - used for JWT signing
 # Defaults to: /etc/deviceauth/rsa/private.pem

--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,12 @@
 
 # tenantadm_addr:  http://tenantadm
 
+# Default tenant token, for devices that don't supply one (optional)
+# Defaults to: none
+# Overwrite with environment variable: DEVICEAUTH_DEFAULT_TENANT_TOKEN
+
+# default_tenant_token:  <VALID_TENANT_TOKEN>
+
 # Private key path - used for JWT signing
 # Defaults to: /etc/deviceauth/rsa/private.pem
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -48,6 +48,9 @@ const (
 	SettingTenantAdmAddr        = "tenantadm_addr"
 	SettingTenantAdmAddrDefault = ""
 
+	SettingDefaultTenantToken        = "default_tenant_token"
+	SettingDefaultTenantTokenDefault = ""
+
 	SettingServerPrivKeyPath        = "server_priv_key_path"
 	SettingServerPrivKeyPathDefault = "/etc/deviceauth/rsa/private.pem"
 
@@ -72,6 +75,7 @@ var (
 		{Key: SettingInventoryAddr, Value: SettingInventoryAddrDefault},
 		{Key: SettingOrchestratorAddr, Value: SettingOrchestratorAddrDefault},
 		{Key: SettingTenantAdmAddr, Value: SettingTenantAdmAddrDefault},
+		{Key: SettingDefaultTenantToken, Value: SettingDefaultTenantTokenDefault},
 		{Key: SettingServerPrivKeyPath, Value: SettingServerPrivKeyPathDefault},
 		{Key: SettingJWTIssuer, Value: SettingJWTIssuerDefault},
 		{Key: SettingJWTExpirationTimeout, Value: SettingJWTExpirationTimeoutDefault},

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ func RunServer(c config.Reader) error {
 			Issuer:                 c.GetString(dconfig.SettingJWTIssuer),
 			ExpirationTime:         int64(c.GetInt(dconfig.SettingJWTExpirationTimeout)),
 			MaxDevicesLimitDefault: uint64(c.GetInt(dconfig.SettingMaxDevicesLimitDefault)),
+			DefaultTenantToken:     c.GetString(dconfig.SettingDefaultTenantToken),
 		})
 
 	if tadmAddr := c.GetString(dconfig.SettingTenantAdmAddr); tadmAddr != "" {


### PR DESCRIPTION
It can be used to allow devices that don't have a tenant token to be
allowed into a specific tenant's list of devices. Enable it either
using the `DEVICEAUTH_DEFAULT_TENANT_TOKEN` environment variable, or
the `default_tenant_token` setting in `config.yaml`.

MEN-2705
MEN-2706

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>