### PR TITLE
Update openssl lib version used in unit tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,8 +106,8 @@ test:unit:
     DEVICEAUTH_MONGO: mongo
   script:
     - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-    - wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u11_amd64.deb
-    - dpkg -i libssl1.0.0_1.0.1t-1+deb8u11_amd64.deb
+    - wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+    - dpkg -i libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
     - echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list
     - apt-get -qq update
     - apt-get install -qy --allow-unauthenticated mongodb-org-server=3.4.6 liblzma-dev


### PR DESCRIPTION
It seems like a new package has been released upstream so the previous
one is not available anymore.