### PR TITLE
mongodb: create index on auth sets collection

### DIFF
--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -1887,7 +1887,7 @@ func TestDevAuthProvisionTenant(t *testing.T) {
 			db := mstore.DataStore{}
 			db.On("MigrateTenant", ctxMatcher,
 				mock.AnythingOfType("string"),
-				"1.5.0",
+				"1.6.0",
 			).Return(tc.datastoreError)
 			db.On("WithAutomigrate").Return(&db)
 			devauth := NewDevAuth(&db, nil, nil, Config{})

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	DbVersion     = "1.5.0"
+	DbVersion     = "1.6.0"
 	DbName        = "deviceauth"
 	DbDevicesColl = "devices"
 	DbAuthSetColl = "auth_sets"
@@ -45,6 +45,7 @@ const (
 	indexDevices_IdentityData                       = "devices:IdentityData"
 	indexAuthSet_DeviceId_IdentityData_PubKey       = "auth_sets:DeviceId:IdData:PubKey"
 	indexAuthSet_DeviceId_IdentityDataSha256_PubKey = "auth_sets:IdDataSha256:PubKey"
+	indexAuthSet_IdentityDataSha256_PubKey          = "auth_sets:NoDeviceId:IdDataSha256:PubKey"
 )
 
 var (
@@ -418,6 +419,10 @@ func (db *DataStoreMongo) MigrateTenant(ctx context.Context, database, version s
 			ctx: ctx,
 		},
 		&migration_1_5_0{
+			ms:  db,
+			ctx: ctx,
+		},
+		&migration_1_6_0{
 			ms:  db,
 			ctx: ctx,
 		},

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -727,7 +727,7 @@ func TestStoreMigrate(t *testing.T) {
 		DbVersion + " no automigrate": {
 			automigrate: false,
 			version:     DbVersion,
-			err:         "failed to apply migrations: db needs migration: deviceauth has version 0.0.0, needs version 1.5.0",
+			err:         "failed to apply migrations: db needs migration: deviceauth has version 0.0.0, needs version 1.6.0",
 		},
 		DbVersion + " multitenant": {
 			automigrate: true,
@@ -739,7 +739,7 @@ func TestStoreMigrate(t *testing.T) {
 			automigrate: false,
 			tenantDbs:   []string{"deviceauth-tenant1id", "deviceauth-tenant2id"},
 			version:     DbVersion,
-			err:         "failed to apply migrations: db needs migration: deviceauth-tenant1id has version 0.0.0, needs version 1.5.0",
+			err:         "failed to apply migrations: db needs migration: deviceauth-tenant1id has version 0.0.0, needs version 1.6.0",
 		},
 		"0.1 error": {
 			automigrate: true,
@@ -817,6 +817,15 @@ func TestStoreMigrate(t *testing.T) {
 										model.AuthSetKeyPubKey,
 									},
 									Name:       indexAuthSet_DeviceId_IdentityDataSha256_PubKey,
+									Background: false,
+								},
+								{
+									Unique: true,
+									Key: []string{
+										model.AuthSetKeyIdDataSha256,
+										model.AuthSetKeyPubKey,
+									},
+									Name:       indexAuthSet_IdentityDataSha256_PubKey,
 									Background: false,
 								},
 							})

--- a/store/mongo/migration_1_6_0.go
+++ b/store/mongo/migration_1_6_0.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+
+	"github.com/globalsign/mgo"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	ctxstore "github.com/mendersoftware/go-lib-micro/store"
+	"github.com/pkg/errors"
+
+	"github.com/mendersoftware/deviceauth/model"
+)
+
+type migration_1_6_0 struct {
+	ms  *DataStoreMongo
+	ctx context.Context
+}
+
+func (m *migration_1_6_0) Up(from migrate.Version) error {
+	s := m.ms.session.Copy()
+
+	defer s.Close()
+
+	err := s.DB(ctxstore.DbFromContext(m.ctx, DbName)).
+		C(DbAuthSetColl).EnsureIndex(mgo.Index{
+		Unique: true,
+		Key: []string{
+			model.AuthSetKeyIdDataSha256,
+			model.AuthSetKeyPubKey,
+		},
+		Name:       indexAuthSet_IdentityDataSha256_PubKey,
+		Background: false,
+	})
+
+	if err != nil {
+		return errors.Wrap(err, "failed to create index containing IdDataSha256 and PubKey on auth sets")
+	}
+
+	return nil
+}
+
+func (m *migration_1_6_0) Version() migrate.Version {
+	return migrate.MakeVersion(1, 6, 0)
+}


### PR DESCRIPTION
New index containing sha256 of identity data and public key created.
Devauth App is looking for auth set existence querying by sha256 of
identity data and public key.