### PR TITLE
Update docker-compose version to 2.1 for acceptance tests

### DIFF
--- a/tests/docker-compose-integration.yml
+++ b/tests/docker-compose-integration.yml
@@ -1,5 +1,0 @@
-version: '2'
-services:
-    mender-device-auth:
-            # built/tagged locally and only used for testing
-            image: mendersoftware/deviceauth:pr

--- a/tests/docker-compose-tenant.yml
+++ b/tests/docker-compose-tenant.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     acceptance:
         image: testing

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     acceptance:
         image: testing


### PR DESCRIPTION
Update docker-compose version to 2.1 for acceptance tests to comply with the rest of the integration compose files.

Also, remove docker-compose-integration.yml