### PR TITLE
QA-149: Use pipelines templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,20 +1,5 @@
-image: golang:1.11
-
-cache:
-  paths:
-    - /apt-cache
-    - /go/src/github.com
-    - /go/src/golang.org
-    - /go/src/google.golang.org
-    - /go/src/gopkg.in
-    - node_modules
-
 variables:
-  DOCKER_HOST: tcp://docker:2375/
-
-services:
-  - docker:dind
-  - mongo
+  DOCKER_REPOSITORY: mendersoftware/deviceauth
 
 stages:
   - test_prep
@@ -22,147 +7,22 @@ stages:
   - build
   - publish
 
-before_script:
-  - export DOCKER_REPOSITORY="mendersoftware/deviceauth"
-  - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
-  - export SERVICE_IMAGE=$DOCKER_REPOSITORY:$DOCKER_TAG
-  - export COMMIT_TAG="$CI_COMMIT_REF_SLUG"_"$CI_COMMIT_SHA"
-
-.template_prep_tests: &test_tool_setup
-  before_script:
-    - mkdir -p /go/src/github.com/mendersoftware /go/src/_/builds
-    - cp -r $CI_PROJECT_DIR /go/src/github.com/mendersoftware/deviceauth
-    - ln -s /go/src/github.com/mendersoftware /go/src/_/builds/mendersoftware
-    - cd /go/src/github.com/mendersoftware/deviceauth
-    # Install code coverage tooling & cyclomatic dependency analysis tool
-    - go get -u github.com/axw/gocov/gocov golang.org/x/tools/cmd/cover github.com/fzipp/gocyclo
-
-test:prepare_acceptance:
-  image: docker
-  stage: test_prep
-  script:
-    - docker build -f Dockerfile.acceptance-testing -t $DOCKER_REPOSITORY:prtest .;
-    - docker save $DOCKER_REPOSITORY:prtest > tests_image.tar
-    - docker build -t $DOCKER_REPOSITORY:pr .
-    - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/binary $DOCKER_REPOSITORY:pr -c "cp /usr/bin/deviceauth /binary"
-    - docker build -t testing -f tests/Dockerfile tests
-    - docker save testing > acceptance_testing_image.tar
-  artifacts:
-    expire_in: 2w
-    paths:
-      - tests_image.tar
-      - acceptance_testing_image.tar
-      - deviceauth
-
-test:acceptance_tests:
-  image: tiangolo/docker-with-compose
-  services:
-    - docker:dind
-  stage: test
-  dependencies:
-    - test:prepare_acceptance
-  script:
-    - apk add git bash
-    - git clone https://github.com/mendersoftware/integration.git
-    - mv integration/extra/travis-testing/* tests/
-    - mv docs/* tests/
-    - mv deviceauth tests/
-    - docker load -i tests_image.tar
-    - docker load -i acceptance_testing_image.tar
-    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose.yml ;
-    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-tenant.yml ;
-  artifacts:
-    expire_in: 2w
-    paths:
-      - tests/coverage-acceptance.txt
-  tags:
-    - docker
+include:
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-golang-static.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-golang-unittests.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-docker-acceptance.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-apidocs.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-docker-build.yml'
 
 test:static:
-  stage: test
-  <<: *test_tool_setup
-  dependencies: []
-  script:
-    - curl -sL https://deb.nodesource.com/setup_11.x | bash -
-    - apt-get -qq update
-    - apt-get install -qy --allow-unauthenticated python3-pip nodejs
-    - pip3 install pyyaml
-    - npm install -g swagger-cli
-    # Get our own Swagger verifier
-    - wget https://raw.githubusercontent.com/mendersoftware/autodocs/master/verify_docs.py
-    # Test if code was formatted with 'go fmt'
-    # Command will format code and return modified files
-    # fail if any have been modified.
-    - if [ -n "$(go fmt)" ]; then echo 'Code is not formatted with "go fmt"'; false; fi
-    # Perform static code analysys
-    - go vet `go list ./... | grep -v vendor`
-    # Fail builds when the cyclomatic complexity reaches 15 or more
-    - gocyclo -over 15 `find . -iname '*.go' | grep -v 'vendor' | grep -v '_test.go'`
-    # Verify that the Swagger docs are valid
-    - swagger-cli validate docs/*.yml
-    # Verify that the Swagger docs follow the autodeployment requirements
-    - if test "$(ls -A docs)"; then python3 verify_docs.py `find docs -name "*.yml"`; fi
+  image: golang:1.11
 
 test:unit:
-  stage: test
-  <<: *test_tool_setup
-  dependencies: []
+  image: golang:1.11
   variables:
     DEVICEAUTH_MONGO: mongo
-  script:
-    - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-    - echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list
-    - apt-get -qq update && apt-get install -qy --allow-unauthenticated mongodb-org-server=3.6.11  liblzma-dev
-    - go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $? ;
-    - mkdir -p tests/unit-coverage && find . -name 'coverage.txt' -exec cp --parents {} ./tests/unit-coverage \;
-    - tar -cvf $CI_PROJECT_DIR/unit-coverage.tar tests/unit-coverage
-  artifacts:
-    expire_in: 2w
-    paths:
-      - unit-coverage.tar
-
-build:
-  image: docker
-  stage: build
-  script:
-    - echo "building deviceauth for ${SERVICE_IMAGE}"
-    - docker build -t $SERVICE_IMAGE .
-    - docker save $SERVICE_IMAGE > image.tar
-  artifacts:
-    expire_in: 2w
-    paths:
-      - image.tar
-  tags:
-    - docker
-
-publish:tests:
-  image: alpine
-  stage: publish
-  before_script:
-    - apk add --no-cache bash curl findutils git
-  dependencies:
-    - test:acceptance_tests
-    - test:unit
-  script:
-    - tar -xvf unit-coverage.tar
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -F unittests -s ./tests/unit-coverage"
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -F acceptance -f ./tests/coverage-acceptance.txt"
-
-publish:build:
-  image: docker:git
-  stage: publish
-  services:
-    - docker:dind
-  dependencies:
-    - build
-  script:
-    - docker load -i image.tar
-    - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$COMMIT_TAG
-    - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$CI_COMMIT_REF_SLUG
-    - echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin
-    - docker push $DOCKER_REPOSITORY:$COMMIT_TAG
-    - docker push $SERVICE_IMAGE
-  only:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/
-  tags:
-    - docker

--- a/Dockerfile.acceptance-testing
+++ b/Dockerfile.acceptance-testing
@@ -1,6 +1,4 @@
 FROM golang:1.11 as builder
-# RUN apk update && apk upgrade && apk add xz-dev musl-dev gcc
-RUN go get -u github.com/axw/gocov/gocov && go get -u golang.org/x/tools/cmd/cover && go get -u github.com/fzipp/gocyclo
 RUN mkdir -p /go/src/github.com/mendersoftware/deviceauth
 COPY . /go/src/github.com/mendersoftware/deviceauth
 RUN cd /go/src/github.com/mendersoftware/deviceauth && \

--- a/tests/docker-compose-acceptance-enterprise.yml
+++ b/tests/docker-compose-acceptance-enterprise.yml
@@ -8,17 +8,22 @@ services:
             - "${TESTS_DIR}:/testing"
         depends_on:
             - mender-device-auth
-        command: -k 'not MultiTenant'
+        # run multi tenant tests only
+        command: -k 'Enterprise'
         environment:
             # run mocked services
-            FAKE_ORCHESTRATOR_ADDR: "0.0.0.0:9998"
+            FAKE_TENANTADM_ADDR: "0.0.0.0:9999"
             FAKE_ADMISSION_ADDR: "0.0.0.0:9997"
+            FAKE_ORCHESTRATOR_ADDR: "0.0.0.0:9998"
     mender-device-auth:
             # built/tagged locally and only used for testing
             image: mendersoftware/deviceauth:prtest
+            volumes:
+                  - "${TESTS_DIR}:/testing"
             environment:
                 # acceptance container will be running mocks for a couple of
                 # services, direct deviceauth there
+                DEVICEAUTH_TENANTADM_ADDR: "http://acceptance:9999/"
                 DEVICEAUTH_DEVICE_AUTH_ORCHESTRATOR: "http://acceptance:9998/"
                 DEVICEAUTH_DEVADM_ADDR: "http://acceptance:9997/"
                 TESTING_LOGS: "1"

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -8,22 +8,17 @@ services:
             - "${TESTS_DIR}:/testing"
         depends_on:
             - mender-device-auth
-        # run multi tenant tests only
-        command: -k 'MultiTenant'
+        command: -k 'not Enterprise'
         environment:
             # run mocked services
-            FAKE_TENANTADM_ADDR: "0.0.0.0:9999"
-            FAKE_ADMISSION_ADDR: "0.0.0.0:9997"
             FAKE_ORCHESTRATOR_ADDR: "0.0.0.0:9998"
+            FAKE_ADMISSION_ADDR: "0.0.0.0:9997"
     mender-device-auth:
             # built/tagged locally and only used for testing
             image: mendersoftware/deviceauth:prtest
-            volumes:
-                  - "${TESTS_DIR}:/testing"
             environment:
                 # acceptance container will be running mocks for a couple of
                 # services, direct deviceauth there
-                DEVICEAUTH_TENANTADM_ADDR: "http://acceptance:9999/"
                 DEVICEAUTH_DEVICE_AUTH_ORCHESTRATOR: "http://acceptance:9998/"
                 DEVICEAUTH_DEVADM_ADDR: "http://acceptance:9997/"
                 TESTING_LOGS: "1"

--- a/tests/tests/test_cli.py
+++ b/tests/tests/test_cli.py
@@ -130,7 +130,7 @@ class TestCliMigrate:
 
 
 @pytest.mark.last
-class TestCliMigrateMultiTenant:
+class TestCliMigrateEnterprise:
     @pytest.mark.parametrize('tenant_id',
             list(MIGRATED_TENANT_DBS) + ['tenant-new-1','tenant-new-2']
             )

--- a/tests/tests/test_device.py
+++ b/tests/tests/test_device.py
@@ -247,7 +247,7 @@ class TestDevice:
             TestDevice.verify_device_count(management_api, 'accepted', 0)
             TestDevice.verify_device_count(management_api, 'rejected', 0)
 
-class TestDeviceMultiTenant:
+class TestDeviceEnterprise:
     @pytest.mark.parametrize('tenant_foobar_devices', ['5'], indirect=True)
     def test_device_limit_applied(self, management_api, internal_api,
                                   tenant_foobar_devices, tenant_foobar):
@@ -328,7 +328,7 @@ class TestDeleteAuthset(TestDeleteAuthsetBase):
         self._test_delete_authset_error_authset_not_found(management_api, devices)
 
 
-class TestDeleteAuthsetMultiTenant(TestDeleteAuthsetBase):
+class TestDeleteAuthsetEnterprise(TestDeleteAuthsetBase):
 
     def test_delete_authset_OK(self, management_api, tenant_foobar_devices, tenant_foobar):
         auth = 'Bearer ' + tenant_foobar

--- a/tests/tests/test_tenant.py
+++ b/tests/tests/test_tenant.py
@@ -26,7 +26,7 @@ from common import Device, DevAuthorizer, \
 import mockserver
 
 
-class TestMultiTenant:
+class TestEnterprise:
 
     def test_auth_req_no_tenantadm(self, management_api, device_api, tenant_foobar):
         d = Device()
@@ -39,7 +39,7 @@ class TestMultiTenant:
         assert rsp.status_code == 500
 
         # request failed, so device should not even be listed as known
-        TestMultiTenant.verify_tenant_dev_present(management_api, d.identity, tenant_foobar,
+        TestEnterprise.verify_tenant_dev_present(management_api, d.identity, tenant_foobar,
                                                   present=False)
 
     def test_auth_req_fake_tenantadm_invalid_tenant_token(self, management_api, device_api,
@@ -62,7 +62,7 @@ class TestMultiTenant:
 
         # request failed, so device should not even be listed as known for the
         # default tenant
-        TestMultiTenant.verify_tenant_dev_present(management_api, d.identity, '',
+        TestEnterprise.verify_tenant_dev_present(management_api, d.identity, '',
                                                   present=False)
 
     def test_auth_req_fake_tenantadm_valid_tenant_token(self, management_api, device_api,
@@ -84,7 +84,7 @@ class TestMultiTenant:
             assert rsp.status_code == 401
 
         # device should be appear in devices listing
-        TestMultiTenant.verify_tenant_dev_present(management_api, d.identity, tenant_foobar,
+        TestEnterprise.verify_tenant_dev_present(management_api, d.identity, tenant_foobar,
                                                   present=True)
 
     def test_auth_req_fake_tenantadm_no_tenant_token(self, management_api, device_api,
@@ -97,7 +97,7 @@ class TestMultiTenant:
         rsp = device_auth_req(url, da, d)
         assert rsp.status_code == 401
 
-        TestMultiTenant.verify_tenant_dev_present(management_api, d.identity, '',
+        TestEnterprise.verify_tenant_dev_present(management_api, d.identity, '',
                                                   present=False)
 
     def test_auth_req_fake_tenantadm_tenant_suspended(self, management_api, device_api,
@@ -121,7 +121,7 @@ class TestMultiTenant:
 
         # request failed, so device should not even be listed as known for the
         # default tenant
-        TestMultiTenant.verify_tenant_dev_present(management_api, d.identity, '',
+        TestEnterprise.verify_tenant_dev_present(management_api, d.identity, '',
                                                   present=False)
 
     @staticmethod
@@ -136,7 +136,7 @@ class TestMultiTenant:
 
     @staticmethod
     def verify_tenant_dev_present(management_api, identity, token, present=False):
-        dev = TestMultiTenant.get_device(management_api, identity, token)
+        dev = TestEnterprise.get_device(management_api, identity, token)
         if present:
             assert dev
         else:

--- a/tests/tests/test_tokens_delete.py
+++ b/tests/tests/test_tokens_delete.py
@@ -98,7 +98,7 @@ def accepted_tenants_devices(device_api, management_api, clean_migrated_db, cli,
     yield tenants_devices
 
 
-class TestMultiTenantDeleteTokens:
+class TestEnterpriseDeleteTokens:
     @pytest.mark.parametrize('accepted_tenants_devices', [[('foo', 2, 2), ('bar', 1, 3)]], indirect=True)
     def test_delete_tokens_by_device_ok(self, accepted_tenants_devices, internal_api, management_api, device_api):
         td = accepted_tenants_devices


### PR DESCRIPTION
Use of CI templates and related fixes.

Depends on https://github.com/mendersoftware/mendertesting/pull/43, commit [31545bd](https://github.com/mendersoftware/deviceauth/pull/310/commits/31545bd2170e08e4c1285fd3641b21bade79338f) will be removed before merge.