### PR TITLE
Fix: Not clearing unused JWT tokens from mongo in all cases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ variables:
   DOCKER_HOST: tcp://docker:2375/
 
 services:
-  - docker:dind
+  - docker:19.03-dind
   - mongo
 
 stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ variables:
   DOCKER_HOST: tcp://docker:2375/
 
 services:
-  - docker:19.03-dind
+  - docker:19.03.5-dind
   - mongo
 
 stages:

--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -448,7 +448,7 @@ func TestDevAuthSubmitAuthRequest(t *testing.T) {
 				},
 				tc.getAuthSetErr)
 
-			db.On("AddToken",
+			db.On("UpsertToken",
 				ctxMatcher,
 				mock.AnythingOfType("model.Token")).Return(nil)
 			db.On("GetDeviceStatus", ctxMatcher,
@@ -557,7 +557,7 @@ func TestDevAuthSubmitAuthRequestPreauth(t *testing.T) {
 			res: dummyToken,
 		},
 		{
-			desc: "error: can't get an existing authset",
+			desc:                     "error: can't get an existing authset",
 			dbGetAuthSetByDataKeyErr: errors.New("db error"),
 			dev: &model.Device{
 				Id:     dummyDevId,
@@ -615,7 +615,7 @@ func TestDevAuthSubmitAuthRequestPreauth(t *testing.T) {
 				Status: model.DevStatusPending,
 			},
 			coSubmitProvisionDeviceJobErr: errors.New("conductor failed"),
-			err: errors.New("submit device provisioning job error: conductor failed"),
+			err:                           errors.New("submit device provisioning job error: conductor failed"),
 		},
 		{
 			desc: "ok: preauthorized set is auto-accepted, device was already accepted",
@@ -634,7 +634,7 @@ func TestDevAuthSubmitAuthRequestPreauth(t *testing.T) {
 				Status: model.DevStatusAccepted,
 			},
 			coSubmitProvisionDeviceJobErr: errors.New("conductor shouldn't be called"),
-			res: dummyToken,
+			res:                           dummyToken,
 		},
 		{
 			desc: "error: cannot get device status",
@@ -718,7 +718,7 @@ func TestDevAuthSubmitAuthRequestPreauth(t *testing.T) {
 
 			// at the end of processing, saves the issued token
 			// only happy path, errors tested elsewhere
-			db.On("AddToken",
+			db.On("UpsertToken",
 				ctx,
 				mock.AnythingOfType("model.Token"),
 			).Return(nil)
@@ -930,8 +930,8 @@ func TestDevAuthAcceptDevice(t *testing.T) {
 				Status: model.DevStatusPending,
 			},
 			coSubmitProvisionDeviceJobErr: errors.New("conductor shouldn't be called"),
-			dbLimit: &model.Limit{Value: 5},
-			dbCount: 4,
+			dbLimit:                       &model.Limit{Value: 5},
+			dbCount:                       4,
 		},
 		{
 			aset: &model.AuthSet{
@@ -944,8 +944,8 @@ func TestDevAuthAcceptDevice(t *testing.T) {
 				Status: model.DevStatusAccepted,
 			},
 			coSubmitProvisionDeviceJobErr: errors.New("conductor shouldn't be called"),
-			dbLimit: &model.Limit{Value: 5},
-			dbCount: 4,
+			dbLimit:                       &model.Limit{Value: 5},
+			dbCount:                       4,
 		},
 		{
 			aset: &model.AuthSet{
@@ -1028,7 +1028,7 @@ func TestDevAuthAcceptDevice(t *testing.T) {
 				Status: model.DevStatusPending,
 			},
 			coSubmitProvisionDeviceJobErr: errors.New("conductor failed"),
-			outErr: "submit device provisioning job error: conductor failed",
+			outErr:                        "submit device provisioning job error: conductor failed",
 		},
 		{
 			dbLimit: &model.Limit{Value: 0},
@@ -1053,7 +1053,7 @@ func TestDevAuthAcceptDevice(t *testing.T) {
 				Status: model.DevStatusPending,
 			},
 			dbUpdateRevokeAuthSetsErr: errors.New("foobar"),
-			outErr: "failed to reject auth sets: foobar",
+			outErr:                    "failed to reject auth sets: foobar",
 		},
 		{
 			aset: &model.AuthSet{
@@ -1487,12 +1487,12 @@ func TestDevAuthDecommissionDevice(t *testing.T) {
 			outErr:            "UpdateDevice Error",
 		},
 		{
-			devId: "devId2",
+			devId:                        "devId2",
 			dbDeleteAuthSetsForDeviceErr: errors.New("DeleteAuthSetsForDevice Error"),
-			outErr: "db delete device authorization sets error: DeleteAuthSetsForDevice Error",
+			outErr:                       "db delete device authorization sets error: DeleteAuthSetsForDevice Error",
 		},
 		{
-			devId: "devId3",
+			devId:                   "devId3",
 			dbDeleteTokenByDevIdErr: errors.New("DeleteTokenByDevId Error"),
 			outErr:                  "db delete device tokens error: DeleteTokenByDevId Error",
 		},
@@ -1502,9 +1502,9 @@ func TestDevAuthDecommissionDevice(t *testing.T) {
 			outErr:            "DeleteDevice Error",
 		},
 		{
-			devId: "devId5",
+			devId:                              "devId5",
 			coSubmitDeviceDecommisioningJobErr: errors.New("SubmitDeviceDecommisioningJob Error"),
-			outErr: "submit device decommissioning job error: SubmitDeviceDecommisioningJob Error",
+			outErr:                             "submit device decommissioning job error: SubmitDeviceDecommisioningJob Error",
 		},
 		{
 			devId:           "devId6",
@@ -1955,10 +1955,10 @@ func TestDevAuthDeleteAuthSet(t *testing.T) {
 			dbDeleteTokenByDevIdErr: store.ErrTokenNotFound,
 		},
 		{
-			devId:  "devId6",
-			authId: "authId6",
+			devId:                       "devId6",
+			authId:                      "authId6",
 			dbDeleteAuthSetForDeviceErr: errors.New("DeleteAuthSetsForDevice Error"),
-			outErr: "DeleteAuthSetsForDevice Error",
+			outErr:                      "DeleteAuthSetsForDevice Error",
 		},
 		{
 			devId:             "devId8",

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ type DataStore interface {
 	DeleteAuthSetForDevice(ctx context.Context, devId string, authId string) error
 
 	// adds JWT to database
-	AddToken(ctx context.Context, t model.Token) error
+	UpsertToken(ctx context.Context, t model.Token) error
 
 	// retrieves JWT from database using JWT Id and device Id
 	// returns ErrTokenNotFound if token not found

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -52,8 +52,8 @@ func (_m *DataStore) AddDevice(ctx context.Context, d model.Device) error {
 	return r0
 }
 
-// AddToken provides a mock function with given fields: ctx, t
-func (_m *DataStore) AddToken(ctx context.Context, t model.Token) error {
+// UpsertToken provides a mock function with given fields: ctx, t
+func (_m *DataStore) UpsertToken(ctx context.Context, t model.Token) error {
 	ret := _m.Called(ctx, t)
 
 	var r0 error

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -237,14 +237,18 @@ func (db *DataStoreMongo) DeleteDevice(ctx context.Context, id string) error {
 	return nil
 }
 
-func (db *DataStoreMongo) AddToken(ctx context.Context, t model.Token) error {
+func (db *DataStoreMongo) UpsertToken(ctx context.Context, t model.Token) error {
 
-	c := db.client.Database(ctxstore.DbFromContext(ctx, DbName)).Collection(DbTokensColl)
+	database := db.client.Database(ctxstore.DbFromContext(ctx, DbName))
+	collTkns := database.Collection(DbTokensColl)
 
-	if _, err := c.InsertOne(ctx, t); err != nil {
+	uOpts := mopts.Update()
+	uOpts.SetUpsert(true)
+	update := bson.M{"$set": t}
+
+	if _, err := collTkns.UpdateOne(ctx, bson.M{"_id": t.Id}, update, uOpts); err != nil {
 		return errors.Wrap(err, "failed to store token")
 	}
-
 	return nil
 }
 

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -28,7 +28,7 @@ import (
 	"github.com/satori/go.uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	mopts "go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/mendersoftware/deviceauth/model"
 	"github.com/mendersoftware/deviceauth/store"
@@ -80,10 +80,10 @@ func NewDataStoreMongo(config DataStoreMongoConfig) (*DataStoreMongo, error) {
 	if !strings.Contains(config.ConnectionString, "://") {
 		config.ConnectionString = "mongodb://" + config.ConnectionString
 	}
-	clientOptions := options.Client().ApplyURI(config.ConnectionString)
+	clientOptions := mopts.Client().ApplyURI(config.ConnectionString)
 
 	if config.Username != "" {
-		clientOptions.SetAuth(options.Credential{
+		clientOptions.SetAuth(mopts.Credential{
 			Username: config.Username,
 			Password: config.Password,
 		})
@@ -557,7 +557,7 @@ func (db *DataStoreMongo) EnsureIndexes(ctx context.Context) error {
 		Keys: bson.D{
 			{Key: model.DevKeyIdData, Value: 1},
 		},
-		Options: &options.IndexOptions{
+		Options: &mopts.IndexOptions{
 			Background: &_false,
 			Name:       &indexDevices_IdentityData,
 			Unique:     &_true,
@@ -570,7 +570,7 @@ func (db *DataStoreMongo) EnsureIndexes(ctx context.Context) error {
 			{Key: model.AuthSetKeyIdData, Value: 1},
 			{Key: model.AuthSetKeyPubKey, Value: 1},
 		},
-		Options: &options.IndexOptions{
+		Options: &mopts.IndexOptions{
 			Background: &_false,
 			Name:       &indexAuthSet_DeviceId_IdentityData_PubKey,
 			Unique:     &_true,
@@ -600,7 +600,7 @@ func (db *DataStoreMongo) PutLimit(ctx context.Context, lim model.Limit) error {
 
 	query := bson.M{"_id": lim.Name}
 
-	updateOptions := options.Update()
+	updateOptions := mopts.Update()
 	updateOptions.SetUpsert(true)
 	if _, err := c.UpdateOne(
 		ctx, query, bson.M{"$set": lim}, updateOptions); err != nil {

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -339,9 +339,9 @@ func TestStoreUpdateDevice(t *testing.T) {
 	}
 }
 
-func TestStoreAddToken(t *testing.T) {
+func TestStoreUpsertToken(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping TestAddToken in short mode.")
+		t.Skip("skipping TestUpsertToken in short mode.")
 	}
 
 	//setup
@@ -356,7 +356,7 @@ func TestStoreAddToken(t *testing.T) {
 	})
 	d := getDb(ctx)
 
-	err := d.AddToken(ctx, token)
+	err := d.UpsertToken(ctx, token)
 	assert.NoError(t, err, "failed to add token")
 
 	//verify


### PR DESCRIPTION
Replaced the insert operation with an upsert. No more than a single device token should be active at the time.