### PR TITLE
device gets tenant's plan in JWT

### DIFF
--- a/client/tenant/client_tenantadm.go
+++ b/client/tenant/client_tenantadm.go
@@ -37,7 +37,6 @@ const (
 
 const (
 	MsgErrTokenVerificationFailed = "tenant token verification failed"
-	MsgErrTokenMissing            = "tenant token missing"
 )
 
 func IsErrTokenVerificationFailed(e error) bool {
@@ -46,10 +45,6 @@ func IsErrTokenVerificationFailed(e error) bool {
 
 func MakeErrTokenVerificationFailed(apiErr error) error {
 	return errors.Wrap(apiErr, MsgErrTokenVerificationFailed)
-}
-
-func IsErrTokenMissing(e error) bool {
-	return strings.HasPrefix(e.Error(), MsgErrTokenMissing)
 }
 
 // ClientConfig conveys client configuration

--- a/client/tenant/mocks/ClientRunner.go
+++ b/client/tenant/mocks/ClientRunner.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+
 package mocks
 
 import apiclient "github.com/mendersoftware/go-lib-micro/apiclient"
@@ -24,17 +25,24 @@ type ClientRunner struct {
 }
 
 // VerifyToken provides a mock function with given fields: ctx, token, client
-func (_m *ClientRunner) VerifyToken(ctx context.Context, token string, client apiclient.HttpRunner) error {
+func (_m *ClientRunner) VerifyToken(ctx context.Context, token string, client apiclient.HttpRunner) (*tenant.Tenant, error) {
 	ret := _m.Called(ctx, token, client)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, apiclient.HttpRunner) error); ok {
+	var r0 *tenant.Tenant
+	if rf, ok := ret.Get(0).(func(context.Context, string, apiclient.HttpRunner) *tenant.Tenant); ok {
 		r0 = rf(ctx, token, client)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tenant.Tenant)
+		}
 	}
 
-	return r0
-}
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, apiclient.HttpRunner) error); ok {
+		r1 = rf(ctx, token, client)
+	} else {
+		r1 = ret.Error(1)
+	}
 
-var _ tenant.ClientRunner = (*ClientRunner)(nil)
+	return r0, r1
+}

--- a/client/tenant/tenant.go
+++ b/client/tenant/tenant.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package tenant
+
+//Tenant is a tenantadm-specific API struct
+type Tenant struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Plan   string `json:"plan"`
+}

--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -478,14 +478,18 @@ func TestDevAuthSubmitAuthRequest(t *testing.T) {
 						mtesting.ContextMatcher(),
 						tc.inReq.TenantToken,
 						mock.AnythingOfType("*apiclient.HttpApi")).
-						Return(tc.tenantVerificationErr)
+						Return(
+							&tenant.Tenant{},
+							tc.tenantVerificationErr)
 				}
 				if tc.config.DefaultTenantToken != "" {
 					ct.On("VerifyToken",
 						mtesting.ContextMatcher(),
 						tc.config.DefaultTenantToken,
 						mock.AnythingOfType("*apiclient.HttpApi")).
-						Return(tc.tenantVerificationErr)
+						Return(
+							&tenant.Tenant{},
+							tc.tenantVerificationErr)
 				}
 				devauth = devauth.WithTenantVerification(&ct)
 			}

--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -271,7 +271,7 @@ func TestDevAuthSubmitAuthRequest(t *testing.T) {
 				PubKey:      pubKey,
 			},
 
-			err: MakeErrDevAuthUnauthorized(errors.New(tenant.MsgErrTokenMissing)),
+			err: MakeErrDevAuthUnauthorized(errors.New("tenant token missing")),
 
 			tenantVerify:          true,
 			tenantVerificationErr: errors.New("should not be called"),

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ type Claims struct {
 	Subject   string `json:"sub,omitempty"`
 	Scope     string `json:"scp,omitempty"`
 	Tenant    string `json:"mender.tenant,omitempty"`
+	Plan      string `json:"mender.plan,omitempty"`
 	Device    bool   `json:"mender.device,omitempty"`
 }
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -242,7 +242,7 @@ def tenant_foobar_devices(device_api, management_api, tenant_foobar, request):
     """
     handlers = [
         ('POST', '/api/internal/v1/tenantadm/tenants/verify',
-         lambda _: (200, {}, '')),
+            lambda _: (200, {}, '{"id": "foobar", "plan": "os"}')),
     ]
     with mockserver.run_fake(get_fake_tenantadm_addr(),
                              handlers=handlers) as fake:


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-3312

add a Plan field to the token issued to the device, so that device APIs will be able to inspect it and switch on it. 

the immediate use is differentiating provides/depends support in `deployments`.

the bare minimum is done in unit/acceptance to get green builds, but the JWT plan verification is done in backend-integration: https://github.com/mendersoftware/integration/pull/864

combined pipeline: https://gitlab.com/Northern.tech/Mender/mender-qa/pipelines/132122327

comment: https://tracker.mender.io/browse/MEN-3312?focusedCommentId=105920&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-105920
