### PR TITLE
MEN-3240 propagate device status to inventory: use the wf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ _testmain.go
 profile.cov
 gover.coverprofile
 profile.coverprofile
+
+.idea
+venv

--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/client/orchestrator/client_orchestrator.go
+++ b/client/orchestrator/client_orchestrator.go
@@ -32,6 +32,7 @@ const (
 	// orchestrator endpoint
 	DeviceDecommissioningOrchestratorUri = "/api/v1/workflow/decommission_device"
 	ProvisionDeviceOrchestratorUri       = "/api/v1/workflow/provision_device"
+	UpdateDeviceStatusOrchestratorUri    = "/api/v1/workflow/update_device_status"
 	// default request timeout, 10s?
 	defaultReqTimeout = time.Duration(10) * time.Second
 )
@@ -58,6 +59,19 @@ type ProvisionDeviceReq struct {
 	Device model.Device `json:"device"`
 }
 
+// UpdateDeviceStatusReq contains request data of request to start update
+// device status  workflow
+type UpdateDeviceStatusReq struct {
+	// Request ID
+	RequestId string `json:"request_id"`
+	// Device IDs
+	Ids string `json:"device_ids"`
+	// Tenant ID
+	TenantId string `json:"tenant_id"`
+	// new status
+	Status string `json:"device_status"`
+}
+
 // Config conveys client configuration
 type Config struct {
 	// Orchestrator host
@@ -70,6 +84,7 @@ type Config struct {
 type ClientRunner interface {
 	SubmitDeviceDecommisioningJob(ctx context.Context, req DecommissioningReq) error
 	SubmitProvisionDeviceJob(ctx context.Context, req ProvisionDeviceReq) error
+	SubmitUpdateDeviceStatusJob(ctx context.Context, req UpdateDeviceStatusReq) error
 }
 
 // Client is an opaque implementation of orchestrator client. Implements
@@ -170,6 +185,53 @@ func (co *Client) SubmitProvisionDeviceJob(ctx context.Context, provisionDeviceR
 
 		return errors.Errorf(
 			"submit provision device request failed with status %v", rsp.Status)
+	}
+	return nil
+}
+
+func (co *Client) SubmitUpdateDeviceStatusJob(ctx context.Context, updateDeviceStatusReq UpdateDeviceStatusReq) error {
+	l := log.FromContext(ctx)
+	client := http.Client{}
+
+	l.Debugf("Submit update device status job for devices: %q", updateDeviceStatusReq.Ids)
+
+	UpdateDeviceStatusReqJson, err := json.Marshal(updateDeviceStatusReq)
+	if err != nil {
+		return errors.Wrapf(err, "failed to submit update device status job")
+	}
+
+	contentReader := bytes.NewReader(UpdateDeviceStatusReqJson)
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		utils.JoinURL(co.conf.OrchestratorAddr, UpdateDeviceStatusOrchestratorUri),
+		contentReader)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// set the device admission request timeout
+	ctx, cancel := context.WithTimeout(ctx, co.conf.Timeout)
+	defer cancel()
+
+	rsp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return errors.Wrapf(err, "failed to submit update device status job")
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode != http.StatusOK && rsp.StatusCode != http.StatusCreated {
+		body, err := ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			body = []byte("<failed to read>")
+		}
+		l.Errorf("update device status request %s %s failed with status %v, response text: %s",
+			req.Method, req.URL, rsp.Status, body)
+
+		return errors.Errorf(
+			"submit update device status request failed with status %v", rsp.Status)
 	}
 	return nil
 }

--- a/client/orchestrator/mocks/ClientRunner.go
+++ b/client/orchestrator/mocks/ClientRunner.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -42,6 +42,19 @@ func (_m *ClientRunner) SubmitProvisionDeviceJob(ctx context.Context, req orches
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, orchestrator.ProvisionDeviceReq) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *ClientRunner) SubmitUpdateDeviceStatusJob(ctx context.Context, req orchestrator.UpdateDeviceStatusReq) error {
+	ret := _m.Called(ctx, req)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, orchestrator.UpdateDeviceStatusReq) error); ok {
 		r0 = rf(ctx, req)
 	} else {
 		r0 = ret.Error(0)

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ func TestMaintenanceWithDataStore(t *testing.T) {
 		},
 		"do nothing with tenant": {
 			decommissioningCleanupFlag: false,
-			tenant: "foo",
+			tenant:                     "foo",
 		},
 		"dry run without data": {
 			decommissioningCleanupFlag: true,
@@ -122,9 +122,9 @@ func TestMaintenanceWithDataStore(t *testing.T) {
 		},
 		"dry run with tenant": {
 			decommissioningCleanupFlag: true,
-			tenant:       "foo",
-			dryRunFlag:   true,
-			withDataSets: true,
+			tenant:                     "foo",
+			dryRunFlag:                 true,
+			withDataSets:               true,
 		},
 		"run without data": {
 			decommissioningCleanupFlag: true,
@@ -135,8 +135,8 @@ func TestMaintenanceWithDataStore(t *testing.T) {
 		},
 		"run with tenant": {
 			decommissioningCleanupFlag: true,
-			tenant:       "foo",
-			withDataSets: true,
+			tenant:                     "foo",
+			withDataSets:               true,
 		},
 	}
 

--- a/model/authset.go
+++ b/model/authset.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -37,6 +37,11 @@ type AuthSet struct {
 	DeviceId     string                 `json:"-" bson:"device_id,omitempty"`
 	Timestamp    *time.Time             `json:"ts" bson:"ts,omitempty"`
 	Status       string                 `json:"status" bson:"status,omitempty"`
+}
+
+type DevAuthSet struct {
+	Id       string `json:"id" bson:"_id,omitempty"`
+	DeviceId string `json:"device_id" bson:"device_id,omitempty"`
 }
 
 type AuthSetUpdate struct {

--- a/tests/common.py
+++ b/tests/common.py
@@ -33,6 +33,7 @@ from client import SimpleInternalClient, SimpleManagementClient, \
     BaseDevicesApiClient
 
 import mockserver
+import orchestrator
 import os
 
 def get_keypair():
@@ -211,13 +212,15 @@ def make_devices(device_api, devcount=1, tenant_token=""):
     url = device_api.auth_requests_url
 
     out_devices = []
-    for _ in range(devcount):
-        dev = Device()
-        da = DevAuthorizer(tenant_token=tenant_token)
-        # poke devauth so that device appears
-        rsp = device_auth_req(url, da, dev)
-        assert rsp.status_code == 401
-        out_devices.append((dev, da))
+
+    with orchestrator.run_fake_for_device_id(1) as server:
+        for _ in range(devcount):
+            dev = Device()
+            da = DevAuthorizer(tenant_token=tenant_token)
+            # poke devauth so that device appears
+            rsp = device_auth_req(url, da, dev)
+            assert rsp.status_code == 401
+            out_devices.append((dev, da))
 
     return out_devices
 

--- a/tests/tests/orchestrator.py
+++ b/tests/tests/orchestrator.py
@@ -52,6 +52,16 @@ def decommission_device_handler(device_id=None, status=200):
 
     return _decommission_device
 
+def update_device_status_handler(device_id=None, status=200):
+    log = logging.getLogger('orchestartor.update_device_status')
+
+    def _update_device_status(request):
+        dreq = json.loads(request.body.decode())
+        print('update_device_status request', dreq)
+        return (status, {}, '')
+
+    return _update_device_status
+
 def get_fake_orchestrator_addr():
     return os.environ.get('FAKE_ORCHESTRATOR_ADDR', '0.0.0.0:9998')
 
@@ -63,11 +73,13 @@ def run_fake_for_device_id(devid, status=None):
         handlers = [
                 ('POST', '/api/v1/workflow/provision_device', provision_device_handler(devid)),
                 ('POST', '/api/v1/workflow/decommission_device', decommission_device_handler(devid)),
+                ('POST', '/api/v1/workflow/update_device_status', update_device_status_handler(devid)),
                 ]
     else:
         handlers = [
                 ('POST', '/api/v1/workflow/provision_device', provision_device_handler(devid, status)),
                 ('POST', '/api/v1/workflow/decommission_device', decommission_device_handler(devid, status)),
+                ('POST', '/api/v1/workflow/update_device_status', update_device_status_handler(devid, status)),
                 ]
 
     with mockserver.run_fake(get_fake_orchestrator_addr(),

--- a/tests/tests/test_mgnt_v2.py
+++ b/tests/tests/test_mgnt_v2.py
@@ -74,24 +74,24 @@ class TestDeleteDevice(ManagementClient):
 
         with orchestrator.run_fake_for_device_id(devid) as server:
             _, rsp = management_api.accept_device(devid, aid)
-        assert rsp.status_code == 204
+            assert rsp.status_code == 204
 
-        # device is accepted, we should get a token now
-        rsp = device_auth_req(url, da, d)
-        assert rsp.status_code == 200
+            # device is accepted, we should get a token now
+            rsp = device_auth_req(url, da, d)
+            assert rsp.status_code == 200
 
-        da.parse_rsp_payload(d, rsp.text)
+            da.parse_rsp_payload(d, rsp.text)
 
-        assert len(d.token) > 0
+            assert len(d.token) > 0
 
-        # reject it now
-        _, rsp = management_api.reject_device(devid, aid)
-        print('RSP:', rsp)
-        assert rsp.status_code == 204
+            # reject it now
+            _, rsp = management_api.reject_device(devid, aid)
+            print('RSP:', rsp)
+            assert rsp.status_code == 204
 
-        # device is rejected, should get unauthorized
-        rsp = device_auth_req(url, da, d)
-        assert rsp.status_code == 401
+            # device is rejected, should get unauthorized
+            rsp = device_auth_req(url, da, d)
+            assert rsp.status_code == 401
 
     def test_device_accept_orchestrator_failure(self, devices, device_api, management_api):
         d, da = devices[0]

--- a/tests/tests/test_tenant.py
+++ b/tests/tests/test_tenant.py
@@ -24,6 +24,7 @@ from common import Device, DevAuthorizer, \
     get_fake_tenantadm_addr
 
 import mockserver
+import orchestrator
 
 
 class TestEnterprise:
@@ -78,10 +79,15 @@ class TestEnterprise:
                  'name': 'Acme',
              })),
         ]
-        with mockserver.run_fake(get_fake_tenantadm_addr(),
-                                handlers=handlers) as fake:
-            rsp = device_auth_req(url, da, d)
-            assert rsp.status_code == 401
+
+        try:
+            with orchestrator.run_fake_for_device_id(1) as server:
+                with mockserver.run_fake(get_fake_tenantadm_addr(),
+                                        handlers=handlers) as fake:
+                    rsp = device_auth_req(url, da, d)
+                    assert rsp.status_code == 401
+        except bravado.exception.HTTPError as e:
+            assert e.response.status_code == 204
 
         # device should be appear in devices listing
         TestEnterprise.verify_tenant_dev_present(management_api, d.identity, tenant_foobar,

--- a/tests/tests/test_tokens_delete.py
+++ b/tests/tests/test_tokens_delete.py
@@ -67,10 +67,15 @@ def accepted_tenants_devices(device_api, management_api, clean_migrated_db, cli,
                          'name': 'Acme',
                      })),
                 ]
-                with mockserver.run_fake(get_fake_tenantadm_addr(),
-                                        handlers=handlers) as fake:
-                    rsp = device_auth_req(url, da, d)
-                    assert rsp.status_code == 401
+
+                try:
+                    with orchestrator.run_fake_for_device_id(1) as server:
+                        with mockserver.run_fake(get_fake_tenantadm_addr(),
+                                                handlers=handlers) as fake:
+                            rsp = device_auth_req(url, da, d)
+                            assert rsp.status_code == 401
+                except bravado.exception.HTTPError as e:
+                    assert e.response.status_code == 204
 
                 # try to find our devices in all devices listing
                 dev = management_api.find_device_by_identity(d.identity,
@@ -85,11 +90,10 @@ def accepted_tenants_devices(device_api, management_api, clean_migrated_db, cli,
                 try:
                     with orchestrator.run_fake_for_device_id(devid) as server:
                         management_api.accept_device(devid, aid, Authorization='Bearer '+ tenant_token)
+                        token = request_token(d, da, device_api.auth_requests_url)
+                        assert len(token) > 0
                 except bravado.exception.HTTPError as e:
                     assert e.response.status_code == 204
-
-                token = request_token(d, da, device_api.auth_requests_url)
-                assert len(token) > 0
 
             assert dev
             tenant_devices.append(d)
@@ -102,136 +106,160 @@ class TestEnterpriseDeleteTokens:
     @pytest.mark.parametrize('accepted_tenants_devices', [[('foo', 2, 2), ('bar', 1, 3)]], indirect=True)
     def test_delete_tokens_by_device_ok(self, accepted_tenants_devices, internal_api, management_api, device_api):
         td = accepted_tenants_devices
+        try:
+            tenant_foo_token = make_fake_tenant_token('foo')
+            da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
+            d1_foo = td['foo'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
+                assert len(token1) > 0
+            d2_foo = td['foo'][1]
+            with orchestrator.run_fake_for_device_id(2) as server:
+                token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        tenant_foo_token = make_fake_tenant_token('foo')
-        da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
-        d1_foo = td['foo'][0]
-        token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
-        assert len(token1) > 0
-        d2_foo = td['foo'][1]
-        token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
-        assert len(token2) > 0
+            tenant_bar_token = make_fake_tenant_token('bar')
+            da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
+            d1_bar = td['bar'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        tenant_bar_token = make_fake_tenant_token('bar')
-        da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
-        d1_bar = td['bar'][0]
-        token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
-        assert len(token2) > 0
+            verify_url = internal_api.make_api_url("/tokens/verify")
+            verify_token(token1, 200, verify_url)
+            verify_token(token2, 200, verify_url)
+            verify_token(token3, 200, verify_url)
 
-        verify_url = internal_api.make_api_url("/tokens/verify")
-        verify_token(token1, 200, verify_url)
-        verify_token(token2, 200, verify_url)
-        verify_token(token3, 200, verify_url)
+            dev1 = management_api.find_device_by_identity(d1_foo.identity,
+                                                          Authorization='Bearer '+ tenant_foo_token)
+            payload = {'device_id': dev1.id, 'tenant_id': 'foo'}
+            rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
+            assert rsp.status_code == 204
 
-        dev1 = management_api.find_device_by_identity(d1_foo.identity,
-                Authorization='Bearer '+ tenant_foo_token)
-        payload = {'device_id': dev1.id, 'tenant_id': 'foo'}
-        rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
-        assert rsp.status_code == 204
+            verify_token(token1, 401, verify_url)
+            verify_token(token2, 200, verify_url)
+            verify_token(token3, 200, verify_url)
+        except bravado.exception.HTTPError as e:
+            assert e.response.status_code == 204
 
-        verify_token(token1, 401, verify_url)
-        verify_token(token2, 200, verify_url)
-        verify_token(token3, 200, verify_url)
 
     @pytest.mark.parametrize('accepted_tenants_devices', [[('foo', 2, 2), ('bar', 1, 3)]], indirect=True)
     def test_delete_tokens_by_non_existent_device_ok(self, accepted_tenants_devices, internal_api, management_api, device_api):
-        td = accepted_tenants_devices
+        try:
+            td = accepted_tenants_devices
 
-        tenant_foo_token = make_fake_tenant_token('foo')
-        da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
-        d1_foo = td['foo'][0]
-        token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
-        assert len(token1) > 0
-        d2_foo = td['foo'][1]
-        token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
-        assert len(token2) > 0
+            tenant_foo_token = make_fake_tenant_token('foo')
+            da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
+            d1_foo = td['foo'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
+                assert len(token1) > 0
+            d2_foo = td['foo'][1]
+            with orchestrator.run_fake_for_device_id(2) as server:
+                token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        tenant_bar_token = make_fake_tenant_token('bar')
-        da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
-        d1_bar = td['bar'][0]
-        token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
-        assert len(token2) > 0
+            tenant_bar_token = make_fake_tenant_token('bar')
+            da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
+            d1_bar = td['bar'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        verify_url = internal_api.make_api_url("/tokens/verify")
-        verify_token(token1, 200, verify_url)
-        verify_token(token2, 200, verify_url)
-        verify_token(token3, 200, verify_url)
+            verify_url = internal_api.make_api_url("/tokens/verify")
+            verify_token(token1, 200, verify_url)
+            verify_token(token2, 200, verify_url)
+            verify_token(token3, 200, verify_url)
 
-        payload = {'device_id': 'foo', 'tenant_id': 'foo'}
-        rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
-        assert rsp.status_code == 204
+            payload = {'device_id': 'foo', 'tenant_id': 'foo'}
+            rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
+            assert rsp.status_code == 204
 
-        verify_token(token1, 200, verify_url)
-        verify_token(token2, 200, verify_url)
-        verify_token(token3, 200, verify_url)
+            verify_token(token1, 200, verify_url)
+            verify_token(token2, 200, verify_url)
+            verify_token(token3, 200, verify_url)
+        except bravado.exception.HTTPError as e:
+            assert e.response.status_code == 204
 
     @pytest.mark.parametrize('accepted_tenants_devices', [[('foo', 2, 2), ('bar', 1, 3)]], indirect=True)
     def test_delete_tokens_by_tenant_ok(self, accepted_tenants_devices, internal_api, management_api, device_api):
-        td = accepted_tenants_devices
+        try:
+            td = accepted_tenants_devices
 
-        tenant_foo_token = make_fake_tenant_token('foo')
-        da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
-        d1_foo = td['foo'][0]
-        token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
-        assert len(token1) > 0
-        d2_foo = td['foo'][1]
-        token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
-        assert len(token2) > 0
+            tenant_foo_token = make_fake_tenant_token('foo')
+            da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
+            d1_foo = td['foo'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
+                assert len(token1) > 0
+            d2_foo = td['foo'][1]
+            with orchestrator.run_fake_for_device_id(2) as server:
+                token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        tenant_bar_token = make_fake_tenant_token('bar')
-        da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
-        d1_bar = td['bar'][0]
-        token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
-        assert len(token2) > 0
+            tenant_bar_token = make_fake_tenant_token('bar')
+            da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
+            d1_bar = td['bar'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        verify_url = internal_api.make_api_url("/tokens/verify")
-        verify_token(token1, 200, verify_url)
-        verify_token(token2, 200, verify_url)
-        verify_token(token3, 200, verify_url)
+            verify_url = internal_api.make_api_url("/tokens/verify")
+            verify_token(token1, 200, verify_url)
+            verify_token(token2, 200, verify_url)
+            verify_token(token3, 200, verify_url)
 
-        dev1 = management_api.find_device_by_identity(d1_foo.identity,
-                Authorization='Bearer '+ tenant_foo_token)
-        payload = {'tenant_id': 'foo'}
-        rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
-        assert rsp.status_code == 204
+            dev1 = management_api.find_device_by_identity(d1_foo.identity,
+                    Authorization='Bearer '+ tenant_foo_token)
+            payload = {'tenant_id': 'foo'}
+            rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
+            assert rsp.status_code == 204
 
-        verify_token(token1, 401, verify_url)
-        verify_token(token2, 401, verify_url)
-        verify_token(token3, 200, verify_url)
+            verify_token(token1, 401, verify_url)
+            verify_token(token2, 401, verify_url)
+            verify_token(token3, 200, verify_url)
+        except bravado.exception.HTTPError as e:
+            assert e.response.status_code == 204
 
     @pytest.mark.parametrize('accepted_tenants_devices', [[('foo', 2, 2), ('bar', 1, 3)]], indirect=True)
     def test_delete_tokens_by_non_existent_tenant_ok(self, accepted_tenants_devices, internal_api, management_api, device_api):
-        td = accepted_tenants_devices
+        try:
+            td = accepted_tenants_devices
 
-        tenant_foo_token = make_fake_tenant_token('foo')
-        da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
-        d1_foo = td['foo'][0]
-        token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
-        assert len(token1) > 0
-        d2_foo = td['foo'][1]
-        token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
-        assert len(token2) > 0
+            tenant_foo_token = make_fake_tenant_token('foo')
+            da_foo = DevAuthorizer(tenant_token=tenant_foo_token)
+            d1_foo = td['foo'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token1 = request_token(d1_foo, da_foo, device_api.auth_requests_url)
+                assert len(token1) > 0
+            d2_foo = td['foo'][1]
+            with orchestrator.run_fake_for_device_id(2) as server:
+                token2 = request_token(d2_foo, da_foo, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        tenant_bar_token = make_fake_tenant_token('bar')
-        da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
-        d1_bar = td['bar'][0]
-        token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
-        assert len(token2) > 0
+            tenant_bar_token = make_fake_tenant_token('bar')
+            da_bar = DevAuthorizer(tenant_token=tenant_bar_token)
+            d1_bar = td['bar'][0]
+            with orchestrator.run_fake_for_device_id(1) as server:
+                token3 = request_token(d1_bar, da_bar, device_api.auth_requests_url)
+                assert len(token2) > 0
 
-        verify_url = internal_api.make_api_url("/tokens/verify")
-        verify_token(token1, 200, verify_url)
-        verify_token(token2, 200, verify_url)
-        verify_token(token3, 200, verify_url)
+            verify_url = internal_api.make_api_url("/tokens/verify")
+            verify_token(token1, 200, verify_url)
+            verify_token(token2, 200, verify_url)
+            verify_token(token3, 200, verify_url)
 
-        dev1 = management_api.find_device_by_identity(d1_foo.identity,
-                Authorization='Bearer '+ tenant_foo_token)
-        payload = {'tenant_id': 'baz'}
-        rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
-        assert rsp.status_code == 204
+            dev1 = management_api.find_device_by_identity(d1_foo.identity,
+                    Authorization='Bearer '+ tenant_foo_token)
+            payload = {'tenant_id': 'baz'}
+            rsp = requests.delete(internal_api.make_api_url("/tokens"), params=payload)
+            assert rsp.status_code == 204
 
-        verify_token(token1, 200, verify_url)
-        verify_token(token2, 200, verify_url)
-        verify_token(token3, 200, verify_url)
+            verify_token(token1, 200, verify_url)
+            verify_token(token2, 200, verify_url)
+            verify_token(token3, 200, verify_url)
+        except bravado.exception.HTTPError as e:
+            assert e.response.status_code == 204
 
     def test_delete_tokens_no_tenant_id_bad_request(self, internal_api):
         rsp = requests.delete(internal_api.make_api_url("/tokens"))


### PR DESCRIPTION
Propagate device status to inventory
--

* **deviceauth** calls _update_device_status_ [[1](https://github.com/mendersoftware/workflows/pull/40)] workflow to propagate information on device status to inventory.
* **inventory** exposes internal API to set status for a list of devices [[2](https://github.com/mendersoftware/inventory-enterprise/pull/24)].
* _/filters/search_ can be use by UI to get list of devices as a single place of information.

related PRs:
 * [1] https://github.com/mendersoftware/workflows/pull/40
 * [2] https://github.com/mendersoftware/inventory/pull/162
 * [3] https://github.com/mendersoftware/deviceauth/pull/324

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>