### PR TITLE
Remove DEVICEAUTH_MAX_DEVICES_LIMIT_DEFAULT configuration option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,10 +59,6 @@ const (
 
 	SettingJWTExpirationTimeout        = "jwt_exp_timeout"
 	SettingJWTExpirationTimeoutDefault = "604800" //one week
-
-	SettingMaxDevicesLimitDefault        = "max_devices_limit_default"
-	SettingMaxDevicesLimitDefaultDefault = "0" // no limit
-
 )
 
 var (
@@ -81,6 +77,5 @@ var (
 		{Key: SettingJWTExpirationTimeout, Value: SettingJWTExpirationTimeoutDefault},
 		{Key: SettingDbSSL, Value: SettingDbSSLDefault},
 		{Key: SettingDbSSLSkipVerify, Value: SettingDbSSLSkipVerifyDefault},
-		{Key: SettingMaxDevicesLimitDefault, Value: SettingMaxDevicesLimitDefaultDefault},
 	}
 )

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -130,8 +130,6 @@ type Config struct {
 	Issuer string
 	// token expiration time
 	ExpirationTime int64
-	// max devices limit default
-	MaxDevicesLimitDefault uint64
 	// Default tenant token to use when the client supplies none. Can be
 	// empty
 	DefaultTenantToken string
@@ -991,9 +989,6 @@ func (d *DevAuth) GetLimit(ctx context.Context, name string) (*model.Limit, erro
 	case nil:
 		return lim, nil
 	case store.ErrLimitNotFound:
-		if name == model.LimitMaxDeviceCount {
-			return &model.Limit{Name: name, Value: d.config.MaxDevicesLimitDefault}, nil
-		}
 		return &model.Limit{Name: name, Value: 0}, nil
 	default:
 		return nil, err

--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -1679,8 +1679,6 @@ func TestDevAuthGetLimit(t *testing.T) {
 
 		outLimit *model.Limit
 		outErr   error
-
-		maxDevicesLimitDefaultConfig uint64
 	}{
 		"ok": {
 			inName: "other_limit",
@@ -1690,8 +1688,6 @@ func TestDevAuthGetLimit(t *testing.T) {
 
 			outLimit: &model.Limit{Name: "other_limit", Value: 123},
 			outErr:   nil,
-
-			maxDevicesLimitDefaultConfig: 456,
 		},
 		"ok max_devices": {
 			inName: model.LimitMaxDeviceCount,
@@ -1701,8 +1697,6 @@ func TestDevAuthGetLimit(t *testing.T) {
 
 			outLimit: &model.Limit{Name: model.LimitMaxDeviceCount, Value: 123},
 			outErr:   nil,
-
-			maxDevicesLimitDefaultConfig: 456,
 		},
 		"limit not found": {
 			inName: "other_limit",
@@ -1712,19 +1706,6 @@ func TestDevAuthGetLimit(t *testing.T) {
 
 			outLimit: &model.Limit{Name: "other_limit", Value: 0},
 			outErr:   nil,
-
-			maxDevicesLimitDefaultConfig: 456,
-		},
-		"limit not found max_devices": {
-			inName: model.LimitMaxDeviceCount,
-
-			dbLimit: nil,
-			dbErr:   store.ErrLimitNotFound,
-
-			outLimit: &model.Limit{Name: model.LimitMaxDeviceCount, Value: 456},
-			outErr:   nil,
-
-			maxDevicesLimitDefaultConfig: 456,
 		},
 		"generic error": {
 			inName: "max_devices",
@@ -1750,8 +1731,7 @@ func TestDevAuthGetLimit(t *testing.T) {
 				mock.AnythingOfType("model.Device"),
 				mock.AnythingOfType("model.DeviceUpdate")).Return(nil)
 
-			devauth := NewDevAuth(&db, nil, nil,
-				Config{MaxDevicesLimitDefault: tc.maxDevicesLimitDefaultConfig})
+			devauth := NewDevAuth(&db, nil, nil, Config{})
 			limit, err := devauth.GetLimit(ctx, tc.inName)
 
 			if tc.outErr != nil {

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -81,10 +81,9 @@ func RunServer(c config.Reader) error {
 		orchestrator.NewClient(orchClientConf),
 		jwtHandler,
 		devauth.Config{
-			Issuer:                 c.GetString(dconfig.SettingJWTIssuer),
-			ExpirationTime:         int64(c.GetInt(dconfig.SettingJWTExpirationTimeout)),
-			MaxDevicesLimitDefault: uint64(c.GetInt(dconfig.SettingMaxDevicesLimitDefault)),
-			DefaultTenantToken:     c.GetString(dconfig.SettingDefaultTenantToken),
+			Issuer:             c.GetString(dconfig.SettingJWTIssuer),
+			ExpirationTime:     int64(c.GetInt(dconfig.SettingJWTExpirationTimeout)),
+			DefaultTenantToken: c.GetString(dconfig.SettingDefaultTenantToken),
 		})
 
 	if tadmAddr := c.GetString(dconfig.SettingTenantAdmAddr); tadmAddr != "" {


### PR DESCRIPTION
The configuration option is considered redundant and is overridden in
enterprise environments.