### PR TITLE
MEN-3506 Porpagate status: migration 1.7.0 and set force migration ve…

### DIFF
--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -1916,7 +1916,7 @@ func TestDevAuthProvisionTenant(t *testing.T) {
 			db := mstore.DataStore{}
 			db.On("MigrateTenant", ctxMatcher,
 				mock.AnythingOfType("string"),
-				"1.6.0",
+				"1.7.0",
 			).Return(tc.datastoreError)
 			db.On("WithAutomigrate").Return(&db)
 			devauth := NewDevAuth(&db, nil, nil, Config{})

--- a/main.go
+++ b/main.go
@@ -110,6 +110,10 @@ func doMain(args []string) {
 					Name:  "tenant_id",
 					Usage: "Tenant ID (optional) - propagate for just a single tenant.",
 				},
+				cli.StringFlag{
+					Name:  "force-set-migration",
+					Usage: "Migration version to be stored in migration_info collection.",
+				},
 				cli.BoolFlag{
 					Name:  "dry-run",
 					Usage: "Do not perform any inventory modifications, just scan and print devices.",
@@ -240,7 +244,11 @@ func cmdPropagateStatusesInventory(args *cli.Context) error {
 	inv := config.Config.GetString(dconfig.SettingInventoryAddr)
 	c := cinv.NewClient(inv, false)
 
-	err = cmd.PropagateStatusesInventory(db, c, args.String("tenant_id"), args.Bool("dry-run"))
+	err = cmd.PropagateStatusesInventory(db,
+		c,
+		args.String("tenant_id"),
+		args.String("force-set-migration"),
+		args.Bool("dry-run"))
 	if err != nil {
 		return cli.NewExitError(err, 7)
 	}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/mendersoftware/deviceauth/model"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
 )
 
 var (
@@ -121,4 +122,7 @@ type DataStore interface {
 
 	MigrateTenant(ctx context.Context, version string, tenant string) error
 	WithAutomigrate() DataStore
+	//call this one if you really know what you are doing. This is supposed to be called only
+	//from cmdPropagateStatusesInventory
+	StoreMigrationVersion(ctx context.Context, version *migrate.Version) error
 }

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -14,7 +14,10 @@
 
 package mocks
 
-import context "context"
+import (
+	context "context"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+)
 import mock "github.com/stretchr/testify/mock"
 import model "github.com/mendersoftware/deviceauth/model"
 import store "github.com/mendersoftware/deviceauth/store"
@@ -480,6 +483,19 @@ func (_m *DataStore) WithAutomigrate() store.DataStore {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.DataStore)
 		}
+	}
+
+	return r0
+}
+
+func (_m *DataStore) StoreMigrationVersion(ctx context.Context, version *migrate.Version) error {
+	ret := _m.Called(ctx, version)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *migrate.Version) error); ok {
+		r0 = rf(ctx, version)
+	} else {
+		r0 = ret.Error(0)
 	}
 
 	return r0

--- a/store/mongo/migration_1_7_0.go
+++ b/store/mongo/migration_1_7_0.go
@@ -1,0 +1,93 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	cinv "github.com/mendersoftware/deviceauth/client/inventory"
+	dconfig "github.com/mendersoftware/deviceauth/config"
+	"time"
+
+	"github.com/mendersoftware/go-lib-micro/config"
+	"github.com/mendersoftware/go-lib-micro/identity"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	ctxstore "github.com/mendersoftware/go-lib-micro/store"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/mendersoftware/deviceauth/model"
+)
+
+type migration_1_7_0 struct {
+	ms  *DataStoreMongo
+	ctx context.Context
+}
+
+const (
+	migrationContextTimeouts = 32
+	devicesBatchSize         = 512
+)
+
+func (m *migration_1_7_0) updateDevicesStatus(ctx context.Context, status string) error {
+	inv := config.Config.GetString(dconfig.SettingInventoryAddr)
+	c := cinv.NewClient(inv, true)
+	collectionDevices := m.ms.client.Database(ctxstore.DbFromContext(m.ctx, DbName)).Collection(DbDevicesColl)
+	opts := options.FindOptions{}
+	opts.SetNoCursorTimeout(true)
+	cur, err := collectionDevices.Find(ctx, bson.M{"status": status}, &opts)
+	if err != nil {
+		return err
+	}
+	id := identity.FromContext(m.ctx)
+	var devicesIds []string
+	devicesIds = make([]string, devicesBatchSize)
+	var i uint
+	i = 0
+	for cur.Next(ctx) {
+		var d model.Device
+		err = cur.Decode(&d)
+		if i >= devicesBatchSize {
+			err = c.SetDeviceStatus(ctx, id.Tenant, devicesIds, status)
+			if err != nil {
+				return err
+			}
+			devicesIds = make([]string, devicesBatchSize)
+			i = 0
+		}
+		devicesIds[i] = d.Id
+		i++
+	}
+	if i >= 1 {
+		err = c.SetDeviceStatus(ctx, id.Tenant, devicesIds[:i], status)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *migration_1_7_0) Up(from migrate.Version) error {
+	ctx, cancel := context.WithTimeout(context.Background(), migrationContextTimeouts*time.Second)
+	defer cancel()
+	m.updateDevicesStatus(ctx, "accepted")
+	m.updateDevicesStatus(ctx, "pending")
+	m.updateDevicesStatus(ctx, "rejected")
+	m.updateDevicesStatus(ctx, "preauthorized")
+
+	return nil
+}
+
+func (m *migration_1_7_0) Version() migrate.Version {
+	return migrate.MakeVersion(1, 7, 0)
+}


### PR DESCRIPTION
…rsion

Migration is added:
 * 1.7.0 version bump
 * for automate upgrades

propagate-inventory-statuses command now supports force-set-migration
 * allows to set the migration version in the db

Misc:
 * store StoreMigrationVersion added

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>