### PR TITLE
ratelimit overrides for tenant-wide settings

### DIFF
--- a/model/api_limits.go
+++ b/model/api_limits.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package model
+
+import (
+	"encoding/json"
+)
+
+type ApiBurst struct {
+	Action         string `json:"action" bson:"action"`
+	Uri            string `json:"uri" bson:"uri"`
+	MinIntervalSec int    `json:"min_interval_sec" bson:"min_interval_sec"`
+}
+
+type ApiQuota struct {
+	MaxCalls    int `json:"max_calls" bson:"max_calls"`
+	IntervalSec int `json:"interval_sec" bson:"interval_sec"`
+}
+
+type ApiLimits struct {
+	ApiBursts []ApiBurst `json:"bursts" bson:"bursts"`
+	ApiQuota  ApiQuota   `json:"quota" bson:"quota"`
+}
+
+// MarshalJSON makes sure even nil ApiBursts (default for all tenants)
+// are actually empty lists
+func (al ApiLimits) MarshalJSON() ([]byte, error) {
+	if al.ApiBursts == nil {
+		al.ApiBursts = make([]ApiBurst, 0)
+	}
+
+	type Copy ApiLimits
+	copy := struct {
+		Copy
+	}{
+		Copy: (Copy)(al),
+	}
+
+	return json.Marshal(&copy)
+}

--- a/model/device.go
+++ b/model/device.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ type Device struct {
 	CreatedTs       time.Time              `json:"created_ts" bson:"created_ts,omitempty"`
 	UpdatedTs       time.Time              `json:"updated_ts" bson:"updated_ts,omitempty"`
 	AuthSets        []AuthSet              `json:"auth_sets" bson:"-"`
+	//ApiLimits override tenant-wide quota/burst config
+	ApiLimits ApiLimits `json:"-" bson:"api_limits"`
 }
 
 type DeviceUpdate struct {


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-3551

tenant-wide ratelimits can be overriden, per device.

overrides will be soon inspected/compared in token verification, i.e. around here: https://github.com/mendersoftware/deviceauth/blob/master/devauth/devauth.go#L996

I'm reusing the same generic structures as https://github.com/mendersoftware/tenantadm/pull/153 - I'll move them to go-lib-micro as a next step.



