### PR TITLE
When preauthorized device is deleted, notify inventory.

### DIFF
--- a/client/inventory/client_test.go
+++ b/client/inventory/client_test.go
@@ -353,7 +353,7 @@ func TestClientSetDeviceIdentity(t *testing.T) {
 		"error: status attribute is reserved": {
 			did: "dsfgr32r23-dfgst34gsdf-34gs-sdgf34",
 			didData: map[string]interface{}{
-				"status":   "accepted",
+				"status": "accepted",
 			},
 
 			err: errors.New("no attributes to update"),


### PR DESCRIPTION
Deviceauth synces all statuses to inventory service.
Incase of device being dismissed from the preauthorized devices list
(user did not accept the device) there is no status to sync, so:

* update device status with _decommissioned_ status is called
* inventory service deletes device when it receives the update

see: inventory/be58c1182b206b7e155b8257d212bd914ffa7773

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>