### PR TITLE
throttling: don't lock out device forever when it doesn't respect bursts

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -240,10 +240,12 @@ func (rl *RedisCache) pipeBurst(ctx context.Context,
 		if b.Action == action &&
 			b.Uri == url &&
 			b.MinIntervalSec != 0 {
-			keyBurst := KeyBurst(tid, id, idtype, url, action)
+
+			intvl := int64(now / int64(b.MinIntervalSec))
+			keyBurst := KeyBurst(tid, id, idtype, url, action, strconv.FormatInt(intvl, 10))
+
 			get = pipe.Get(ctx, keyBurst)
 			set = pipe.Set(ctx, keyBurst, now, time.Duration(b.MinIntervalSec)*time.Second)
-
 		}
 	}
 
@@ -320,8 +322,8 @@ func KeyQuota(tid, id, idtype, intvlNum string) string {
 	return fmt.Sprintf("tenant:%s:%s:%s:quota:%s", tid, idtype, id, intvlNum)
 }
 
-func KeyBurst(tid, id, idtype, url, action string) string {
-	return fmt.Sprintf("tenant:%s:%s:%s:burst:%s:%s", tid, idtype, id, url, action)
+func KeyBurst(tid, id, idtype, url, action, intvlNum string) string {
+	return fmt.Sprintf("tenant:%s:%s:%s:burst:%s:%s:%s", tid, idtype, id, url, action, intvlNum)
 }
 
 func KeyToken(tid, id, idtype string) string {

--- a/utils/time.go
+++ b/utils/time.go
@@ -21,6 +21,7 @@ func UnixMilis() int64 {
 
 type Clock interface {
 	Now() time.Time
+	Forward(secs int64)
 }
 
 type clock struct{}
@@ -31,6 +32,10 @@ func NewClock() *clock {
 
 func (c *clock) Now() time.Time {
 	return time.Now()
+}
+
+func (c *clock) Forward(secs int64) {
+	//noop
 }
 
 type mockClock struct {
@@ -45,4 +50,8 @@ func NewMockClock(unixNow int64) *mockClock {
 
 func (mc *mockClock) Now() time.Time {
 	return time.Unix(mc.unixNow, 0)
+}
+
+func (mc *mockClock) Forward(secs int64) {
+	mc.unixNow += secs
 }


### PR DESCRIPTION
Quick followup based on demo feedback:
https://tracker.mender.io/browse/MEN-3698

A new burst tracking strategy is implemented, where a device spamming more frequently than `min_interval_sec` will be still allowed every `min_interval_sec`. This is contrary to the old strategy, where the device would be denied every time just because of the short burst time.

It's implemented similarily to quotas (multiple burst keys, one per min_interval_sec time window, rolling over regularly and expiring accordingly).

Aside from that, some general improvements in cache tests are introduced (mock time source for cache, emulate time flow for both miniredis and cache to capture limit counters actually being created and rolled over in both components).