### PR TITLE
API spec fixes: schema and hostname

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -6,7 +6,7 @@ info:
     An API for device authentication handling. Intended for use by devices.
 
 basePath: '/api/devices/v1/authentication'
-host: 'docker.mender.io'
+host: 'hosted.mender.io'
 schemes:
   - https
 

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -8,7 +8,7 @@ info:
 basePath: '/api/management/v2/devauth/'
 host: 'mender-device-auth:8080'
 schemes:
-  - http
+  - https
 
 paths:
   /devices:

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -6,7 +6,7 @@ info:
       An API for device authentication handling.
 
 basePath: '/api/management/v2/devauth/'
-host: 'mender-device-auth:8080'
+host: 'hosted.mender.io'
 schemes:
   - https
 


### PR DESCRIPTION
* [API spec] Consistently use host hosted.mender.io across all repos
* [API spec] Consistently use https schemes across all repos