### PR TITLE
index on id data sha256, not id data

### DIFF
--- a/model/device.go
+++ b/model/device.go
@@ -26,8 +26,9 @@ const (
 	DevStatusPreauth  = "preauthorized"
 	DevStatusNoAuth   = "noauth"
 
-	DevKeyIdData = "id_data"
-	DevKeyStatus = "status"
+	DevKeyIdData       = "id_data"
+	DevKeyIdDataSha256 = "id_data_sha256"
+	DevKeyStatus       = "status"
 )
 
 // note: fields with underscores need the 'bson' decorator

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	DbVersion     = "1.8.0"
+	DbVersion     = "1.9.0"
 	DbName        = "deviceauth"
 	DbDevicesColl = "devices"
 	DbAuthSetColl = "auth_sets"
@@ -47,6 +47,7 @@ const (
 
 var (
 	indexDevices_IdentityData                       = "devices:IdentityData"
+	indexDevices_IdentityDataSha256                 = "devices:IdentityDataSha256"
 	indexAuthSet_DeviceId_IdentityData_PubKey       = "auth_sets:DeviceId:IdData:PubKey"
 	indexAuthSet_DeviceId_IdentityDataSha256_PubKey = "auth_sets:IdDataSha256:PubKey"
 	indexAuthSet_IdentityDataSha256_PubKey          = "auth_sets:NoDeviceId:IdDataSha256:PubKey"
@@ -425,6 +426,10 @@ func (db *DataStoreMongo) MigrateTenant(ctx context.Context, database, version s
 			ctx: ctx,
 		},
 		&migration_1_8_0{
+			ds:  db,
+			ctx: ctx,
+		},
+		&migration_1_9_0{
 			ds:  db,
 			ctx: ctx,
 		},

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -586,48 +586,6 @@ func (db *DataStoreMongo) WithAutomigrate() store.DataStore {
 	}
 }
 
-func (db *DataStoreMongo) EnsureIndexes(ctx context.Context) error {
-	_false := false
-	_true := true
-
-	devIdDataUniqueIndex := mongo.IndexModel{
-		Keys: bson.D{
-			{Key: model.DevKeyIdData, Value: 1},
-		},
-		Options: &mopts.IndexOptions{
-			Background: &_false,
-			Name:       &indexDevices_IdentityData,
-			Unique:     &_true,
-		},
-	}
-
-	authSetUniqueIndex := mongo.IndexModel{
-		Keys: bson.D{
-			{Key: model.AuthSetKeyDeviceId, Value: 1},
-			{Key: model.AuthSetKeyIdData, Value: 1},
-			{Key: model.AuthSetKeyPubKey, Value: 1},
-		},
-		Options: &mopts.IndexOptions{
-			Background: &_false,
-			Name:       &indexAuthSet_DeviceId_IdentityData_PubKey,
-			Unique:     &_true,
-		},
-	}
-
-	cDevs := db.client.Database(ctxstore.DbFromContext(ctx, DbName)).Collection(DbDevicesColl)
-	devIndexes := cDevs.Indexes()
-	_, err := devIndexes.CreateOne(ctx, devIdDataUniqueIndex)
-	if err != nil {
-		return err
-	}
-
-	cAuthSets := db.client.Database(ctxstore.DbFromContext(ctx, DbName)).Collection(DbAuthSetColl)
-	authSetIndexes := cAuthSets.Indexes()
-	_, err = authSetIndexes.CreateOne(ctx, authSetUniqueIndex)
-
-	return err
-}
-
 func (db *DataStoreMongo) PutLimit(ctx context.Context, lim model.Limit) error {
 	if lim.Name == "" {
 		return errors.New("empty limit name")

--- a/store/mongo/datastore_mongo_cleanup_test.go
+++ b/store/mongo/datastore_mongo_cleanup_test.go
@@ -45,6 +45,7 @@ func TestGetDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -52,6 +53,7 @@ func TestGetDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: true,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 			outDevices: []model.Device{
@@ -61,6 +63,7 @@ func TestGetDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: true,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 		},
@@ -72,6 +75,7 @@ func TestGetDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -79,11 +83,13 @@ func TestGetDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: true,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 			outDevices: []model.Device{
 				model.Device{
-					Id: "002",
+					Id:           "002",
+					IdDataSha256: getIdDataHash("002"),
 				},
 			},
 			tenant: tenant,
@@ -134,6 +140,7 @@ func TestDeleteDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -141,6 +148,7 @@ func TestDeleteDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: true,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 		},
@@ -152,6 +160,7 @@ func TestDeleteDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -159,6 +168,7 @@ func TestDeleteDevicesBeingDecommissioned(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: true,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 			tenant: tenant,
@@ -231,6 +241,7 @@ func TestGetBrokenAuthSets(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -238,6 +249,7 @@ func TestGetBrokenAuthSets(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 			outAuthSetsIds: []string{"002"},
@@ -382,6 +394,7 @@ func TestDeleteBrokenAuthSets(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -389,6 +402,7 @@ func TestDeleteBrokenAuthSets(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 		},
@@ -414,6 +428,7 @@ func TestDeleteBrokenAuthSets(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -421,6 +436,7 @@ func TestDeleteBrokenAuthSets(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 			tenant: tenant,
@@ -447,6 +463,7 @@ func TestDeleteBrokenAuthSets(t *testing.T) {
 					PubKey:          "001",
 					Status:          model.DevStatusPending,
 					Decommissioning: false,
+					IdDataSha256:    getIdDataHash("001"),
 				},
 				model.Device{
 					Id:              "002",
@@ -454,6 +471,7 @@ func TestDeleteBrokenAuthSets(t *testing.T) {
 					PubKey:          "002",
 					Status:          model.DevStatusPending,
 					Decommissioning: true,
+					IdDataSha256:    getIdDataHash("002"),
 				},
 			},
 			tenant: tenant,

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -831,29 +831,17 @@ func TestStoreMigrate(t *testing.T) {
 						verifyIndexes(t, db.client.Database(d).Collection(DbDevicesColl),
 							[]mongo.IndexModel{{
 								Keys: bson.D{
-									{Key: model.DevKeyIdData, Value: 1},
+									{Key: model.DevKeyIdDataSha256, Value: 1},
 								},
 								Options: &options.IndexOptions{
 									Background: &_false,
-									Name:       &indexDevices_IdentityData,
+									Name:       &indexDevices_IdentityDataSha256,
 									Unique:     &_true,
 								},
 							}},
 						)
 						verifyIndexes(t, db.client.Database(d).Collection(DbAuthSetColl),
 							[]mongo.IndexModel{
-								{
-									Keys: bson.D{
-										{Key: model.AuthSetKeyDeviceId, Value: 1},
-										{Key: model.AuthSetKeyIdData, Value: 1},
-										{Key: model.AuthSetKeyPubKey, Value: 1},
-									},
-									Options: &options.IndexOptions{
-										Background: &_false,
-										Name:       &indexAuthSet_DeviceId_IdentityData_PubKey,
-										Unique:     &_true,
-									},
-								},
 								{
 									Keys: bson.D{
 										{Key: model.AuthSetKeyDeviceId, Value: 1},

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -279,8 +279,9 @@ func TestStoreAddDevice(t *testing.T) {
 
 	// add device with identical identity data
 	err = d.AddDevice(ctx, model.Device{
-		Id:     "foobar",
-		IdData: "iddata",
+		Id:           "foobar",
+		IdData:       "iddata",
+		IdDataSha256: getIdDataHash("iddata"),
 	})
 	assert.EqualError(t, err, store.ErrObjectExists.Error())
 
@@ -2373,18 +2374,21 @@ func TestStoreGetDeviceById(t *testing.T) {
 	time.Local = time.UTC
 
 	indescr := []struct {
-		id     string
-		idData string
-		limits ratelimits.ApiLimits
+		id           string
+		idData       string
+		idDataSha256 []byte
+		limits       ratelimits.ApiLimits
 	}{
 		{
-			id:     "dev1",
-			idData: "idData1",
+			id:           "dev1",
+			idData:       "idData1",
+			idDataSha256: getIdDataHash("idData1"),
 			//default limits
 		},
 		{
-			id:     "dev2",
-			idData: "idData2",
+			id:           "dev2",
+			idData:       "idData2",
+			idDataSha256: getIdDataHash("idData2"),
 			limits: ratelimits.ApiLimits{
 				ApiQuota: ratelimits.ApiQuota{
 					MaxCalls:    100,
@@ -2405,8 +2409,9 @@ func TestStoreGetDeviceById(t *testing.T) {
 			},
 		},
 		{
-			id:     "dev3",
-			idData: "idData4",
+			id:           "dev3",
+			idData:       "idData4",
+			idDataSha256: getIdDataHash("idData4"),
 			limits: ratelimits.ApiLimits{
 				ApiQuota: ratelimits.ApiQuota{
 					MaxCalls:    1000,
@@ -2420,6 +2425,7 @@ func TestStoreGetDeviceById(t *testing.T) {
 	indevs := make([]interface{}, len(indescr))
 	for i, descr := range indescr {
 		dev := model.NewDevice(oid.NewUUIDv5(descr.id).String(), descr.idData, "")
+		dev.IdDataSha256 = descr.idDataSha256
 		dev.ApiLimits = descr.limits
 		indevs[i] = dev
 	}

--- a/store/mongo/migration_1_9_0.go
+++ b/store/mongo/migration_1_9_0.go
@@ -1,0 +1,78 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	ctxstore "github.com/mendersoftware/go-lib-micro/store"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	mopts "go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/mendersoftware/deviceauth/model"
+)
+
+type migration_1_9_0 struct {
+	ds  *DataStoreMongo
+	ctx context.Context
+}
+
+// Up removes device and authset indexes which include raw id data
+// and creates device index on id data sha256
+func (m *migration_1_9_0) Up(from migrate.Version) error {
+	_false := false
+	_true := true
+
+	// create device index on id data sha
+	devIdDataSha256UniqueIndex := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: model.DevKeyIdDataSha256, Value: 1},
+		},
+		Options: &mopts.IndexOptions{
+			Background: &_false,
+			Name:       &indexDevices_IdentityDataSha256,
+			Unique:     &_true,
+		},
+	}
+
+	cDevs := m.ds.client.Database(ctxstore.DbFromContext(m.ctx, DbName)).Collection(DbDevicesColl)
+	devIndexes := cDevs.Indexes()
+	_, err := devIndexes.CreateOne(m.ctx, devIdDataSha256UniqueIndex)
+	if err != nil {
+		return errors.Wrap(err, "failed to create unique index containing IdDataSha256 on devices")
+	}
+
+	// drop device index on raw identity data
+	_, err = devIndexes.DropOne(m.ctx, indexDevices_IdentityData)
+	if err != nil {
+		return errors.Wrap(err, "failed to drop index devices:IdentityData")
+	}
+
+	// drop authset index on raw identity data
+	cAuthsets := m.ds.client.Database(ctxstore.DbFromContext(m.ctx, DbName)).Collection(DbAuthSetColl)
+	asetIndexes := cAuthsets.Indexes()
+	_, err = asetIndexes.DropOne(m.ctx, indexAuthSet_DeviceId_IdentityData_PubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to drop index auth_sets:DeviceId:IdData:PubKey")
+	}
+
+	return nil
+}
+
+func (m *migration_1_9_0) Version() migrate.Version {
+	return migrate.MakeVersion(1, 9, 0)
+}

--- a/store/mongo/migration_1_9_0_test.go
+++ b/store/mongo/migration_1_9_0_test.go
@@ -1,0 +1,221 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/mendersoftware/go-lib-micro/identity"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mendersoftware/deviceauth/model"
+)
+
+func TestMigration_1_9_0(t *testing.T) {
+	ts := time.Now()
+
+	ctx := identity.WithContext(context.Background(), &identity.Identity{
+		Tenant: "foo",
+	})
+	db.Wipe()
+	db := NewDataStoreMongoWithClient(db.Client())
+
+	prep_1_8_0(t, ctx, db)
+
+	devs := []model.Device{
+		{
+			Id:              "1",
+			IdData:          "{\"sn\":\"0001\",\"mac\":\"00:00:00:01\"}",
+			IdDataSha256:    getIdDataHash("{\"sn\":\"0001\",\"mac\":\"00:00:00:01\"}"),
+			PubKey:          "key1",
+			Status:          "accepted",
+			Decommissioning: false,
+			CreatedTs:       ts,
+			UpdatedTs:       ts,
+		},
+		{
+			Id:              "2",
+			IdData:          "{\"sn\":\"0002\",\"attr\":\"foo1\",\"mac\":\"00:00:00:02\"}",
+			IdDataSha256:    getIdDataHash("{\"sn\":\"0002\",\"attr\":\"foo1\",\"mac\":\"00:00:00:02\"}"),
+			PubKey:          "key2",
+			Status:          "accepted",
+			Decommissioning: false,
+			CreatedTs:       ts,
+			UpdatedTs:       ts,
+		},
+	}
+
+	asets := []model.AuthSet{
+		{
+			Id:        "1",
+			DeviceId:  "1",
+			IdData:    "{\"sn\":\"0001\",\"mac\":\"00:00:00:01\"}",
+			Status:    "accepted",
+			PubKey:    "key1",
+			Timestamp: &ts,
+		},
+		{
+			Id:        "2",
+			DeviceId:  "2",
+			IdData:    "{\"sn\":\"0002\",\"attr\":\"foo\",\"mac\":\"00:00:00:02\"}",
+			Status:    "accepted",
+			PubKey:    "key2",
+			Timestamp: &ts,
+		},
+	}
+
+	for _, d := range devs {
+		err := db.AddDevice(ctx, d)
+		assert.NoError(t, err)
+	}
+
+	for _, a := range asets {
+		err := db.AddAuthSet(ctx, a)
+		assert.NoError(t, err)
+	}
+
+	// try device or authset with 'too large' id data - should fail
+	idData := randstr(1025)
+	devTooLarge := model.Device{
+		Id:              "3",
+		IdData:          idData,
+		IdDataSha256:    getIdDataHash(idData),
+		PubKey:          "key3",
+		Status:          "accepted",
+		Decommissioning: false,
+		CreatedTs:       ts,
+		UpdatedTs:       ts,
+	}
+
+	err := db.AddDevice(ctx, devTooLarge)
+	assert.NotNil(t, err)
+
+	asetTooLarge := model.AuthSet{
+		Id:           "3",
+		DeviceId:     "3",
+		IdData:       idData,
+		IdDataSha256: getIdDataHash(idData),
+		Status:       "accepted",
+		PubKey:       "key3",
+		Timestamp:    &ts,
+	}
+	err = db.AddAuthSet(ctx, asetTooLarge)
+	assert.NotNil(t, err)
+
+	// test new version, long id data added successfully
+	mig190 := migration_1_9_0{
+		ds:  db,
+		ctx: ctx,
+	}
+	err = mig190.Up(migrate.MakeVersion(1, 9, 0))
+	assert.NoError(t, err)
+
+	err = db.AddDevice(ctx, devTooLarge)
+	assert.Nil(t, err)
+
+	err = db.AddAuthSet(ctx, asetTooLarge)
+	assert.Nil(t, err)
+
+	// verify our uniqueness invariants
+	// can't add device with duplicated id data sha
+	dev := model.Device{
+		Id:           "4",
+		IdDataSha256: getIdDataHash(idData),
+	}
+	err = db.AddDevice(ctx, dev)
+	assert.EqualError(t, err, "object exists")
+
+	// can't add authset with duplicated dev id + id data sha + pubkey
+	aset := model.AuthSet{
+		Id:           "4",
+		DeviceId:     "3",
+		IdDataSha256: getIdDataHash(idData),
+		PubKey:       "key3",
+	}
+	err = db.AddAuthSet(ctx, aset)
+	assert.EqualError(t, err, "object exists")
+
+	// can't add authset with duplicated id data sha + pubkey
+	aset = model.AuthSet{
+		Id:           "4",
+		IdDataSha256: getIdDataHash(idData),
+		PubKey:       "key3",
+	}
+	err = db.AddAuthSet(ctx, aset)
+	assert.EqualError(t, err, "object exists")
+}
+
+func prep_1_8_0(t *testing.T, ctx context.Context, db *DataStoreMongo) {
+
+	mig110 := migration_1_1_0{
+		ms:  db,
+		ctx: ctx,
+	}
+	mig120 := migration_1_2_0{
+		ms:  db,
+		ctx: ctx,
+	}
+	mig130 := migration_1_3_0{
+		ms:  db,
+		ctx: ctx,
+	}
+	mig140 := migration_1_4_0{
+		ms:  db,
+		ctx: ctx,
+	}
+	mig150 := migration_1_5_0{
+		ms:  db,
+		ctx: ctx,
+	}
+	mig160 := migration_1_6_0{
+		ms:  db,
+		ctx: ctx,
+	}
+	mig170 := migration_1_7_0{
+		ms:  db,
+		ctx: ctx,
+	}
+	mig180 := migration_1_8_0{
+		ds:  db,
+		ctx: ctx,
+	}
+
+	err := mig110.Up(migrate.MakeVersion(1, 1, 0))
+	assert.NoError(t, err)
+	err = mig120.Up(migrate.MakeVersion(1, 2, 0))
+	assert.NoError(t, err)
+	err = mig130.Up(migrate.MakeVersion(1, 3, 0))
+	assert.NoError(t, err)
+	err = mig140.Up(migrate.MakeVersion(1, 4, 0))
+	assert.NoError(t, err)
+	err = mig150.Up(migrate.MakeVersion(1, 5, 0))
+	assert.NoError(t, err)
+	err = mig160.Up(migrate.MakeVersion(1, 6, 0))
+	assert.NoError(t, err)
+	err = mig170.Up(migrate.MakeVersion(1, 7, 0))
+	assert.NoError(t, err)
+	err = mig180.Up(migrate.MakeVersion(1, 8, 0))
+	assert.NoError(t, err)
+}
+
+func randstr(n int) string {
+	b := make([]byte, n)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}

--- a/tests/tests/test_cli.py
+++ b/tests/tests/test_cli.py
@@ -18,14 +18,14 @@ import pytest
 
 DB_NAME = "deviceauth"
 DB_MIGRATION_COLLECTION = "migration_info"
-DB_VERSION = "1.1.0"
+DB_VERSION = "1.9.0"
 
 
 MIGRATED_TENANT_DBS={
     "tenant-stale-1": "0.0.1",
     "tenant-stale-2": "0.2.0",
     "tenant-stale-3": "1.0.0",
-    "tenant-current": "1.1.0",
+    "tenant-current": "1.9.0",
     "tenant-future": "2.0.0",
 }
 
@@ -119,7 +119,7 @@ class TestCliMigrate:
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, DB_VERSION)
 
-    @pytest.mark.parametrize('fake_migrated_db', ["1.0.0"], indirect=True)
+    @pytest.mark.parametrize('fake_migrated_db', ["1.9.0"], indirect=True)
     def test_ok_current_db(self, cli, fake_migrated_db, mongo):
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, DB_VERSION)

--- a/tests/tests/test_cli.py
+++ b/tests/tests/test_cli.py
@@ -80,6 +80,7 @@ class TestMigration:
 
         mi = db[DB_MIGRATION_COLLECTION].find_one(version)
         print('found migration:', mi)
+
         assert mi
 
     @staticmethod
@@ -118,7 +119,7 @@ class TestCliMigrate:
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, DB_VERSION)
 
-    @pytest.mark.parametrize('fake_migrated_db', ["1.1.0"], indirect=True)
+    @pytest.mark.parametrize('fake_migrated_db', ["1.0.0"], indirect=True)
     def test_ok_current_db(self, cli, fake_migrated_db, mongo):
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, DB_VERSION)


### PR DESCRIPTION
prevents 'index key too large' errors.

https://tracker.mender.io/browse/MEN-3816