### PR TITLE
tests: Update docker image and python packages for acceptance tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.5
+FROM python:3.8
 
-RUN pip3 install --quiet bravado==9.2.2 pymongo==3.6.1 pytest-ordering==0.5 minio pycrypto pytest==3.10.1 twisted requests pyyaml flask tornado
+RUN pip3 install --quiet bravado==9.2.2 pymongo==3.11.0 pytest-ordering==0.6 minio cryptography==3.1.1 pytest==6.1.1 twisted requests pyyaml flask tornado
 
 RUN mkdir -p /testing
 ENTRYPOINT ["bash", "/testing/run.sh"]

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,39 +25,56 @@ from pymongo import MongoClient
 
 import pytest
 
-from Crypto.PublicKey import RSA
-from Crypto.Signature import PKCS1_v1_5
-from Crypto.Hash import SHA256
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.backends import default_backend
 
-from client import SimpleInternalClient, SimpleManagementClient, \
-    BaseDevicesApiClient
+from client import SimpleInternalClient, SimpleManagementClient, BaseDevicesApiClient
 
 import mockserver
 import orchestrator
 import os
 
+
 def get_keypair():
-    private = RSA.generate(1024)
-    public = private.publickey()
-    return private.exportKey().decode(), public.exportKey().decode()
+    private = rsa.generate_private_key(65537, 1024, default_backend())
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+    return private_pem, public_pem
 
 
 def sign_data(data, privateKey):
-    rsakey = RSA.importKey(privateKey)
-    signer = PKCS1_v1_5.new(rsakey)
-    digest = SHA256.new()
-    if type(data) is str:
-        data = data.encode()
-    digest.update(data)
-    sign = signer.sign(digest)
+    rsakey = serialization.load_pem_private_key(
+        data=privateKey if isinstance(privateKey, bytes) else privateKey.encode(),
+        password=None,
+        backend=default_backend(),
+    )
+    sign = rsakey.sign(
+        data if isinstance(data, bytes) else data.encode(),
+        padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
     return b64encode(sign)
 
 
 class Device(object):
     def __init__(self, id_data=None):
         if id_data is None:
-            mac = ":".join(["{:02x}".format(random.randint(0x00, 0xFF), 'x') for i in range(6)])
-            self.identity = json.dumps({"mac": mac}).replace(" ","")
+            mac = ":".join(
+                ["{:02x}".format(random.randint(0x00, 0xFF), "x") for i in range(6)]
+            )
+            self.identity = json.dumps({"mac": mac}).replace(" ", "")
         else:
             self.identity = id_data
 
@@ -74,11 +91,13 @@ class DevAuthorizer(object):
 
     def make_req_payload(self, dev):
         """Make auth request for given device. Returns a tuple (payload, signature)"""
-        payload = json.dumps({
-            "id_data": dev.identity,
-            "tenant_token": self.tenant_token,
-            "pubkey": dev.public_key,
-        })
+        payload = json.dumps(
+            {
+                "id_data": dev.identity,
+                "tenant_token": self.tenant_token,
+                "pubkey": dev.public_key,
+            }
+        )
         signature = sign_data(payload, dev.private_key)
         return payload, signature
 
@@ -110,14 +129,14 @@ def make_devid(identity):
     d.update(bid)
     return binascii.b2a_hex(d.digest()).decode()
 
+
 def b64pad(b64data):
-    """Pad base64 string with '=' to achieve a length that is a multiple of 4
-    """
-    return b64data + '=' * (4 - (len(b64data) % 4))
+    """Pad base64 string with '=' to achieve a length that is a multiple of 4"""
+    return b64data + "=" * (4 - (len(b64data) % 4))
 
 
 def explode_jwt(token):
-    parts = token.split('.')
+    parts = token.split(".")
     assert len(parts) == 3
 
     # JWT fields are passed in a header and use URL safe encoding, which
@@ -132,23 +151,25 @@ def explode_jwt(token):
 
     return hdr, claims, sign
 
+
 @pytest.fixture(scope="session")
 def cli():
     return CliClient()
 
+
 @pytest.fixture(scope="session")
 def mongo():
-    return MongoClient('mender-mongo:27017')
+    return MongoClient("mender-mongo:27017")
 
 
 def mongo_cleanup(mongo):
-    dbs = mongo.database_names()
-    dbs = [d for d in dbs if d not in ['local', 'admin', 'config']]
+    dbs = mongo.list_database_names()
+    dbs = [d for d in dbs if d not in ["local", "admin", "config"]]
     for d in dbs:
         mongo.drop_database(d)
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def clean_db(mongo):
     """Fixture setting up a clean (i.e. empty database). Yields
     pymongo.MongoClient connected to the DB."""
@@ -156,30 +177,41 @@ def clean_db(mongo):
     yield mongo
     mongo_cleanup(mongo)
 
-@pytest.yield_fixture(scope='function')
+
+@pytest.yield_fixture(scope="function")
 def clean_migrated_db(clean_db, cli):
     """Clean database with migrations applied. Yields pymongo.MongoClient connected to the DB."""
     cli.migrate()
     yield clean_db
 
-@pytest.yield_fixture(scope='function')
+
+@pytest.yield_fixture(scope="function")
 def tenant_foobar_clean_migrated_db(clean_db, cli):
     """Clean 'foobar' database with migrations applied. Yields pymongo.MongoClient connected to the DB."""
-    cli.migrate(tenant='foobar')
+    cli.migrate(tenant="foobar")
     yield clean_db
 
-@pytest.yield_fixture(scope='session')
-def management_api():
-    yield SimpleManagementClient()
 
-@pytest.yield_fixture(scope='session')
-def internal_api():
-    yield SimpleInternalClient()
+@pytest.yield_fixture(scope="session")
+def management_api(request):
+    yield SimpleManagementClient(
+        request.config.getoption("--host"),
+        request.config.getoption("--management-spec"),
+    )
 
 
-@pytest.yield_fixture(scope='session')
-def device_api():
-    yield BaseDevicesApiClient()
+@pytest.yield_fixture(scope="session")
+def internal_api(request):
+    yield SimpleInternalClient(
+        request.config.getoption("--host"),
+        request.config.getoption("--spec"),
+    )
+
+
+@pytest.yield_fixture(scope="session")
+def device_api(request):
+    yield BaseDevicesApiClient(request.config.getoption("--host"))
+
 
 def make_fake_tenant_token(tenant):
     """make_fake_tenant_token will generate a JWT-like tenant token which looks
@@ -187,28 +219,27 @@ def make_fake_tenant_token(tenant):
     issuer (Mender), subject (fake-tenant), mender.tenant (foobar)
     """
     claims = {
-        'iss': 'Mender',
-        'sub': 'fake-tenant',
-        'mender.tenant': tenant,
+        "iss": "Mender",
+        "sub": "fake-tenant",
+        "mender.tenant": tenant,
     }
 
     # serialize claims to JSON, encode as base64 and strip padding to be
     # compatible with JWT
-    enc = urlsafe_b64encode(json.dumps(claims).encode()). \
-          decode().strip('==')
+    enc = urlsafe_b64encode(json.dumps(claims).encode()).decode().strip("==")
 
-    return 'fake.' + enc + '.fake-sig'
+    return "fake." + enc + ".fake-sig"
+
 
 @pytest.fixture
 def tenant_foobar(request, tenant_foobar_clean_migrated_db):
     """Fixture that sets up a tenant with ID 'foobar', on top of a clean migrated
     (with tenant support) DB.
     """
-    return make_fake_tenant_token('foobar')
+    return make_fake_tenant_token("foobar")
+
 
 def make_devices(device_api, devcount=1, tenant_token=""):
-    print('device count to generate', devcount)
-
     url = device_api.auth_requests_url
 
     out_devices = []
@@ -225,37 +256,41 @@ def make_devices(device_api, devcount=1, tenant_token=""):
     return out_devices
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def devices(device_api, clean_migrated_db, request):
     """Make unauthorized devices. The fixture can be parametrized a number of
     devices to make. Yields a list of tuples:
     (instance of Device, instance of DevAuthorizer)"""
-    if not hasattr(request, 'param'):
+    if not hasattr(request, "param"):
         devcount = 1
     else:
         devcount = int(request.param)
 
     yield make_devices(device_api, devcount)
 
-@pytest.yield_fixture(scope='function')
+
+@pytest.yield_fixture(scope="function")
 def tenant_foobar_devices(device_api, management_api, tenant_foobar, request):
     """Make unauthorized devices owned by tenant with ID 'foobar'. The fixture can
     be parametrized a number of devices to make. Yields a list of tuples:
     (instance of Device, instance of DevAuthorizer)
     """
     handlers = [
-        ('POST', '/api/internal/v1/tenantadm/tenants/verify',
-            lambda _: (200, {}, '{"id": "foobar", "plan": "os"}')),
+        (
+            "POST",
+            "/api/internal/v1/tenantadm/tenants/verify",
+            lambda _: (200, {}, '{"id": "foobar", "plan": "os"}'),
+        ),
     ]
-    with mockserver.run_fake(get_fake_tenantadm_addr(),
-                             handlers=handlers) as fake:
+    with mockserver.run_fake(get_fake_tenantadm_addr(), handlers=handlers) as fake:
 
-        if not hasattr(request, 'param'):
+        if not hasattr(request, "param"):
             devcount = 1
         else:
             devcount = int(request.param)
 
         yield make_devices(device_api, devcount, tenant_token=tenant_foobar)
 
+
 def get_fake_tenantadm_addr():
-    return os.environ.get('FAKE_TENANTADM_ADDR', '0.0.0.0:9999')
+    return os.environ.get("FAKE_TENANTADM_ADDR", "0.0.0.0:9999")

--- a/tests/tests/cryptutil.py
+++ b/tests/tests/cryptutil.py
@@ -12,10 +12,9 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from Crypto.PublicKey import RSA
 
-def compare_keys(a,b):
-    ai = RSA.importKey(a)
-    bi = RSA.importKey(b)
 
-    return ai.exportKey().decode() == bi.exportKey().decode()
+def compare_keys(a, b):
+    a_b64 = "".join(list(filter(None, a.splitlines()))[1:-1])
+    b_b64 = "".join(list(filter(None, b.splitlines()))[1:-1])
+    return a_b64 == b_b64

--- a/tests/tests/test_cli.py
+++ b/tests/tests/test_cli.py
@@ -21,7 +21,7 @@ DB_MIGRATION_COLLECTION = "migration_info"
 DB_VERSION = "1.9.0"
 
 
-MIGRATED_TENANT_DBS={
+MIGRATED_TENANT_DBS = {
     "tenant-stale-1": "0.0.1",
     "tenant-stale-2": "0.2.0",
     "tenant-stale-3": "1.0.0",
@@ -29,23 +29,24 @@ MIGRATED_TENANT_DBS={
     "tenant-future": "2.0.0",
 }
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def migrated_tenant_dbs(clean_db, mongo):
-    ''' Init a set of tenant dbs to predefined versions. '''
+    """ Init a set of tenant dbs to predefined versions. """
     for tid, ver in MIGRATED_TENANT_DBS.items():
         mongo_set_version(mongo, make_tenant_db(tid), ver)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def fake_migrated_db(clean_db, mongo, request):
-    '''Init a default db to version passed in 'request'. Does not run the actual
-    migrations, just records DB version in proper collection.'''
+    """Init a default db to version passed in 'request'. Does not run the actual
+    migrations, just records DB version in proper collection."""
     version = request.param
     mongo_set_version(mongo, DB_NAME, version)
 
 
 def mongo_set_version(mongo, dbname, version):
-    major, minor, patch = [int(x) for x in version.split('.')]
+    major, minor, patch = [int(x) for x in version.split(".")]
 
     version = {
         "major": major,
@@ -57,13 +58,13 @@ def mongo_set_version(mongo, dbname, version):
 
 
 def make_tenant_db(tenant_id):
-    return '{}-{}'.format(DB_NAME, tenant_id)
+    return "{}-{}".format(DB_NAME, tenant_id)
 
 
 class TestMigration:
     @staticmethod
     def verify_db_and_collections(client, dbname):
-        dbs = client.database_names()
+        dbs = client.list_database_names()
         assert dbname in dbs
 
         colls = client[dbname].collection_names()
@@ -71,7 +72,7 @@ class TestMigration:
 
     @staticmethod
     def verify_migration(db, expected_version):
-        major, minor, patch = [int(x) for x in expected_version.split('.')]
+        major, minor, patch = [int(x) for x in expected_version.split(".")]
         version = {
             "version.major": major,
             "version.minor": minor,
@@ -79,7 +80,7 @@ class TestMigration:
         }
 
         mi = db[DB_MIGRATION_COLLECTION].find_one(version)
-        print('found migration:', mi)
+        print("found migration:", mi)
 
         assert mi
 
@@ -88,14 +89,14 @@ class TestMigration:
         TestMigration.verify_db_and_collections(mongo, dbname)
         TestMigration.verify_migration(mongo[dbname], version)
 
-class TestListTenants:
 
+class TestListTenants:
     def test_ok(self, cli, migrated_tenant_dbs):
         dbs = list(MIGRATED_TENANT_DBS.keys())
         dbs.sort()
         listedTenants = cli.list_tenants()
         listedTenantsList = listedTenants.split("\n")
-        listedTenantsList.remove('')
+        listedTenantsList.remove("")
         listedTenantsList.sort()
         assert dbs == listedTenantsList
 
@@ -114,17 +115,17 @@ class TestCliMigrate:
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, DB_VERSION)
 
-    @pytest.mark.parametrize('fake_migrated_db', ["0.0.1"], indirect=True)
+    @pytest.mark.parametrize("fake_migrated_db", ["0.0.1"], indirect=True)
     def test_ok_stale_db(self, cli, fake_migrated_db, mongo):
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, DB_VERSION)
 
-    @pytest.mark.parametrize('fake_migrated_db', ["1.9.0"], indirect=True)
+    @pytest.mark.parametrize("fake_migrated_db", ["1.9.0"], indirect=True)
     def test_ok_current_db(self, cli, fake_migrated_db, mongo):
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, DB_VERSION)
 
-    @pytest.mark.parametrize('fake_migrated_db', ["2.0.0"], indirect=True)
+    @pytest.mark.parametrize("fake_migrated_db", ["2.0.0"], indirect=True)
     def test_ok_future_db(self, cli, fake_migrated_db, mongo):
         cli.migrate()
         TestMigration.verify(cli, mongo, DB_NAME, "2.0.0")
@@ -132,9 +133,9 @@ class TestCliMigrate:
 
 @pytest.mark.last
 class TestCliMigrateEnterprise:
-    @pytest.mark.parametrize('tenant_id',
-            list(MIGRATED_TENANT_DBS) + ['tenant-new-1','tenant-new-2']
-            )
+    @pytest.mark.parametrize(
+        "tenant_id", list(MIGRATED_TENANT_DBS) + ["tenant-new-1", "tenant-new-2"]
+    )
     def test_ok(self, cli, mongo, migrated_tenant_dbs, tenant_id):
         cli.migrate(tenant_id)
 

--- a/tests/tests/test_internal_api.py
+++ b/tests/tests/test_internal_api.py
@@ -17,25 +17,25 @@ from common import clean_db, mongo, internal_api
 
 import bravado
 
-class TestInternalApi:
 
+class TestInternalApi:
     def test_create_tenant_ok(self, internal_api, clean_db):
-        _, r = internal_api.create_tenant('foobar')
+        _, r = internal_api.create_tenant("foobar")
         assert r.status_code == 201
 
-        assert 'deviceauth-foobar' in clean_db.database_names()
-        assert 'migration_info' in clean_db['deviceauth-foobar'].collection_names()
+        assert "deviceauth-foobar" in clean_db.list_database_names()
+        assert "migration_info" in clean_db["deviceauth-foobar"].collection_names()
 
     def test_create_tenant_twice(self, internal_api, clean_db):
-        _, r = internal_api.create_tenant('foobar')
+        _, r = internal_api.create_tenant("foobar")
         assert r.status_code == 201
 
         # creating once more should not fail
-        _, r = internal_api.create_tenant('foobar')
+        _, r = internal_api.create_tenant("foobar")
         assert r.status_code == 201
 
     def test_create_tenant_empty(self, internal_api):
         try:
-            _, r = internal_api.create_tenant('')
+            _, r = internal_api.create_tenant("")
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 400

--- a/tests/tests/test_mgnt_v2.py
+++ b/tests/tests/test_mgnt_v2.py
@@ -2,17 +2,30 @@ from client import ManagementClient
 import bravado
 import json
 import pytest
-from common import Device, DevAuthorizer, \
-    device_auth_req, make_devices, devices, \
-    clean_migrated_db, clean_db, mongo, cli, \
-    management_api, internal_api, device_api, \
-    tenant_foobar, tenant_foobar_devices, tenant_foobar_clean_migrated_db,\
-    get_keypair
+from common import (
+    Device,
+    DevAuthorizer,
+    device_auth_req,
+    make_devices,
+    devices,
+    clean_migrated_db,
+    clean_db,
+    mongo,
+    cli,
+    management_api,
+    internal_api,
+    device_api,
+    tenant_foobar,
+    tenant_foobar_devices,
+    tenant_foobar_clean_migrated_db,
+    get_keypair,
+)
 
 from tenantadm import fake_tenantadm
 import orchestrator
 
-class TestDeleteDevice(ManagementClient):
+
+class TestDeleteDevice:
     def test_delete_device(self, management_api, devices):
         # try delete an existing device, verify decommissioning workflow was started
         # setup single device and poke devauth
@@ -21,12 +34,14 @@ class TestDeleteDevice(ManagementClient):
         assert ourdev
 
         with orchestrator.run_fake_for_device_id(ourdev.id) as server:
-            rsp = management_api.delete_device(ourdev.id, {
-                'X-MEN-RequestID':'delete_device',
-                'Authorization': 'Bearer foobar',
-                })
-        print('decommission request finished with status:',
-              rsp.status_code)
+            rsp = management_api.delete_device(
+                ourdev.id,
+                {
+                    "X-MEN-RequestID": "delete_device",
+                    "Authorization": "Bearer foobar",
+                },
+            )
+        print("decommission request finished with status:", rsp.status_code)
         assert rsp.status_code == 204
 
         found = None
@@ -47,17 +62,19 @@ class TestDeleteDevice(ManagementClient):
         assert ourdev
 
         with orchestrator.run_fake_for_device_id(ourdev.id, 500) as server:
-            rsp = management_api.delete_device(ourdev.id, {
-                'X-MEN-RequestID':'delete_device',
-                'Authorization': 'Bearer foobar',
-                })
-        print('decommission request finished with status:',
-              rsp.status_code)
+            rsp = management_api.delete_device(
+                ourdev.id,
+                {
+                    "X-MEN-RequestID": "delete_device",
+                    "Authorization": "Bearer foobar",
+                },
+            )
+        print("decommission request finished with status:", rsp.status_code)
         assert rsp.status_code == 500
 
     def test_delete_device_nonexistent(self, management_api):
         # try delete a nonexistent device
-        rsp = management_api.delete_device('some-devid-foo')
+        rsp = management_api.delete_device("some-devid-foo")
         assert rsp.status_code == 404
 
     def test_device_accept_reject_cycle(self, devices, device_api, management_api):
@@ -69,7 +86,7 @@ class TestDeleteDevice(ManagementClient):
         assert dev
         devid = dev.id
 
-        print('found device with ID:', dev.id)
+        print("found device with ID:", dev.id)
         aid = dev.auth_sets[0].id
 
         with orchestrator.run_fake_for_device_id(devid) as server:
@@ -86,14 +103,16 @@ class TestDeleteDevice(ManagementClient):
 
             # reject it now
             _, rsp = management_api.reject_device(devid, aid)
-            print('RSP:', rsp)
+            print("RSP:", rsp)
             assert rsp.status_code == 204
 
             # device is rejected, should get unauthorized
             rsp = device_auth_req(url, da, d)
             assert rsp.status_code == 401
 
-    def test_device_accept_orchestrator_failure(self, devices, device_api, management_api):
+    def test_device_accept_orchestrator_failure(
+        self, devices, device_api, management_api
+    ):
         d, da = devices[0]
         url = device_api.auth_requests_url
 
@@ -102,7 +121,7 @@ class TestDeleteDevice(ManagementClient):
         assert dev
         devid = dev.id
 
-        print('found device with ID:', dev.id)
+        print("found device with ID:", dev.id)
         aid = dev.auth_sets[0].id
 
         status = None


### PR DESCRIPTION
Python 3.5 has already reached EOL so bumped the image to python 3.8.
Moreover, pycrypto seems to no longer be maintained and makes use of
deprecated function time.clock breaking compatibility with python 3.8
leading to the replacement with `cryptography` package. Finally, the
pymongo version was bumped to the latest stable as well to suppress some
deprecation warnings.