### PR TITLE
MEN-4062: Add deviceconnect service to workflows

### DIFF
--- a/client/orchestrator/client_orchestrator.go
+++ b/client/orchestrator/client_orchestrator.go
@@ -162,7 +162,7 @@ func (co *Client) SubmitProvisionDeviceJob(ctx context.Context, provisionDeviceR
 
 	l := log.FromContext(ctx)
 
-	l.Debugf("Submit provision device job for device: %s", provisionDeviceReq.Device.Id)
+	l.Debugf("Submit provision device job for device: %s", provisionDeviceReq.DeviceID)
 
 	ProvisionDeviceReqJson, err := json.Marshal(provisionDeviceReq)
 	if err != nil {

--- a/client/orchestrator/models.go
+++ b/client/orchestrator/models.go
@@ -15,7 +15,6 @@
 package orchestrator
 
 import (
-	"github.com/mendersoftware/deviceauth/model"
 	"github.com/pkg/errors"
 )
 
@@ -37,8 +36,10 @@ type ProvisionDeviceReq struct {
 	// User authorization, eg. the value of Authorization header of incoming
 	// HTTP request
 	Authorization string `json:"authorization"`
-	// Device
-	Device model.Device `json:"device"`
+	// DeviceID
+	DeviceID string `json:"device_id"`
+	// TenantID
+	TenantID string `json:"tenant_id"`
 }
 
 // UpdateDeviceStatusReq contains request data of request to start update

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/mendersoftware/deviceauth/client/inventory"
 	"net/http"
 	"strings"
 	"time"
@@ -37,6 +36,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/mendersoftware/deviceauth/cache"
+	"github.com/mendersoftware/deviceauth/client/inventory"
 	"github.com/mendersoftware/deviceauth/client/orchestrator"
 	"github.com/mendersoftware/deviceauth/client/tenant"
 	"github.com/mendersoftware/deviceauth/jwt"
@@ -726,17 +726,18 @@ func (d *DevAuth) DeleteAuthSet(ctx context.Context, devID string, authId string
 				"db delete device tokens error")
 		}
 	} else if authSet.Status == model.DevStatusPreauth {
-		// only delete the device if the set is 'preauthorized'
-		// otherwise device data may live in other services too,
-		// and is a case for decommissioning
-		err = d.db.DeleteDevice(ctx, devID)
-		if err != nil {
-			return err
-		}
-		tenantId := ""
+		// if the auth set status is 'preauthorized', the device is deleted from
+		// deviceauth. We cannot start the decommission_device workflow because
+		// we don't provision devices until they are accepted. Still, we need to
+		// remove the device from the inventory service because we index pre-authorized
+		// devices for consumption via filtering APIs. To trigger the deletion
+		// from the inventory service, we start the status update workflow with the
+		// special value "decommissioned", which will cause the deletion of the
+		// device from the inventory service's database
+		tenantID := ""
 		idData := identity.FromContext(ctx)
 		if idData != nil {
-			tenantId = idData.Tenant
+			tenantID = idData.Tenant
 		}
 		b, err := json.Marshal([]string{devID})
 		if err != nil {
@@ -747,12 +748,14 @@ func (d *DevAuth) DeleteAuthSet(ctx context.Context, devID string, authId string
 			orchestrator.UpdateDeviceStatusReq{
 				RequestId: requestid.FromContext(ctx),
 				Ids:       string(b), // []string{dev.Id},
-				TenantId:  tenantId,
+				TenantId:  tenantID,
 				Status:    "decommissioned",
 			}); err != nil {
 			return errors.Wrap(err, "update device status job error")
 		}
-		return err
+
+		// delete device
+		return d.db.DeleteDevice(ctx, devID)
 	}
 
 	return d.updateDeviceStatus(ctx, devID, "", authSet.Status)

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -461,6 +461,10 @@ func (d *DevAuth) processPreAuthRequest(ctx context.Context, r *model.AuthReq) (
 
 	if !deviceAlreadyAccepted {
 		reqId := requestid.FromContext(ctx)
+		var tenantID string
+		if idty := identity.FromContext(ctx); idty != nil {
+			tenantID = idty.Tenant
+		}
 
 		// submit device accepted job
 		if err := d.cOrch.SubmitProvisionDeviceJob(
@@ -468,9 +472,8 @@ func (d *DevAuth) processPreAuthRequest(ctx context.Context, r *model.AuthReq) (
 			orchestrator.ProvisionDeviceReq{
 				RequestId:     reqId,
 				Authorization: ctxhttpheader.FromContext(ctx, "Authorization"),
-				Device: model.Device{
-					Id: aset.DeviceId,
-				},
+				DeviceID:      aset.DeviceId,
+				TenantID:      tenantID,
 			}); err != nil {
 			return nil, errors.Wrap(err, "submit device provisioning job error")
 		}
@@ -812,15 +815,19 @@ func (d *DevAuth) AcceptDeviceAuth(ctx context.Context, device_id string, auth_i
 
 	reqId := requestid.FromContext(ctx)
 
+	var tenantID string
+	if idty := identity.FromContext(ctx); idty != nil {
+		tenantID = idty.Tenant
+	}
+
 	// submit device accepted job
 	if err := d.cOrch.SubmitProvisionDeviceJob(
 		ctx,
 		orchestrator.ProvisionDeviceReq{
 			RequestId:     reqId,
 			Authorization: ctxhttpheader.FromContext(ctx, "Authorization"),
-			Device: model.Device{
-				Id: aset.DeviceId,
-			},
+			DeviceID:      aset.DeviceId,
+			TenantID:      tenantID,
 		}); err != nil {
 		return errors.Wrap(err, "submit device provisioning job error")
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.6.1
-	github.com/urfave/cli v1.22.4
+	github.com/urfave/cli v1.22.5
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
 	go.mongodb.org/mongo-driver v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
-github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc h1:n+nNi93yXLkJvKwXNP9d55HC7lGK4H/SRcwB5IaUZLo=

--- a/tests/tests/orchestrator.py
+++ b/tests/tests/orchestrator.py
@@ -22,66 +22,93 @@ import mockserver
 
 
 def provision_device_handler(device_id=None, status=200):
-    log = logging.getLogger('orchestartor.provision_device')
+    log = logging.getLogger("orchestartor.provision_device")
 
     def _provision_device(request):
-        device = json.loads(request.body.decode())['device']
-        log.info('provision device %s', device)
+        payload = json.loads(request.body.decode())
         if device_id is not None:
-            assert device.get('id', None) == device_id
+            assert payload.get("device_id", None) == device_id
         else:
-            assert device.get('id', None)
+            assert "device_id" in payload
 
-        return (status, {}, '')
+        return (status, {}, "")
 
     return _provision_device
 
+
 def decommission_device_handler(device_id=None, status=200):
-    log = logging.getLogger('orchestartor.decommision_device')
+    log = logging.getLogger("orchestartor.decommision_device")
 
     def _decommission_device(request):
         dreq = json.loads(request.body.decode())
-        print('decommision request', dreq)
+        print("decommision request", dreq)
         # verify that devauth tries to decommision correct device
-        assert dreq.get('device_id', None) == device_id
+        assert dreq.get("device_id", None) == device_id
         # test is enforcing particular request ID
-        assert dreq.get('request_id', None) == 'delete_device'
+        assert dreq.get("request_id", None) == "delete_device"
         # test is enforcing particular request ID
-        assert dreq.get('authorization', None) == 'Bearer foobar'
-        return (status, {}, '')
+        assert dreq.get("authorization", None) == "Bearer foobar"
+        return (status, {}, "")
 
     return _decommission_device
 
+
 def update_device_status_handler(device_id=None, status=200):
-    log = logging.getLogger('orchestartor.update_device_status')
+    log = logging.getLogger("orchestartor.update_device_status")
 
     def _update_device_status(request):
         dreq = json.loads(request.body.decode())
-        print('update_device_status request', dreq)
-        return (status, {}, '')
+        print("update_device_status request", dreq)
+        return (status, {}, "")
 
     return _update_device_status
 
+
 def get_fake_orchestrator_addr():
-    return os.environ.get('FAKE_ORCHESTRATOR_ADDR', '0.0.0.0:9998')
+    return os.environ.get("FAKE_ORCHESTRATOR_ADDR", "0.0.0.0:9998")
+
 
 ANY_DEVICE = None
+
 
 @contextmanager
 def run_fake_for_device_id(devid, status=None):
     if status is None:
         handlers = [
-                ('POST', '/api/v1/workflow/provision_device', provision_device_handler(devid)),
-                ('POST', '/api/v1/workflow/decommission_device', decommission_device_handler(devid)),
-                ('POST', '/api/v1/workflow/update_device_status', update_device_status_handler(devid)),
-                ]
+            (
+                "POST",
+                "/api/v1/workflow/provision_device",
+                provision_device_handler(devid),
+            ),
+            (
+                "POST",
+                "/api/v1/workflow/decommission_device",
+                decommission_device_handler(devid),
+            ),
+            (
+                "POST",
+                "/api/v1/workflow/update_device_status",
+                update_device_status_handler(devid),
+            ),
+        ]
     else:
         handlers = [
-                ('POST', '/api/v1/workflow/provision_device', provision_device_handler(devid, status)),
-                ('POST', '/api/v1/workflow/decommission_device', decommission_device_handler(devid, status)),
-                ('POST', '/api/v1/workflow/update_device_status', update_device_status_handler(devid, status)),
-                ]
+            (
+                "POST",
+                "/api/v1/workflow/provision_device",
+                provision_device_handler(devid, status),
+            ),
+            (
+                "POST",
+                "/api/v1/workflow/decommission_device",
+                decommission_device_handler(devid, status),
+            ),
+            (
+                "POST",
+                "/api/v1/workflow/update_device_status",
+                update_device_status_handler(devid, status),
+            ),
+        ]
 
-    with mockserver.run_fake(get_fake_orchestrator_addr(),
-                             handlers=handlers) as server:
+    with mockserver.run_fake(get_fake_orchestrator_addr(), handlers=handlers) as server:
         yield server

--- a/vendor/github.com/urfave/cli/app.go
+++ b/vendor/github.com/urfave/cli/app.go
@@ -263,8 +263,6 @@ func (a *App) Run(arguments []string) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
-			_, _ = fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
-			_ = ShowAppHelp(context)
 			a.handleExitCoder(context, beforeErr)
 			err = beforeErr
 			return err

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -161,7 +161,6 @@ func (c Command) Run(ctx *Context) (err error) {
 	if c.Before != nil {
 		err = c.Before(context)
 		if err != nil {
-			_ = ShowCommandHelp(context, c.Name)
 			context.App.handleExitCoder(context, err)
 			return err
 		}

--- a/vendor/github.com/urfave/cli/context.go
+++ b/vendor/github.com/urfave/cli/context.go
@@ -324,11 +324,12 @@ func checkRequiredFlags(flags []Flag, context *Context) requiredFlagsErr {
 			var flagPresent bool
 			var flagName string
 			for _, key := range strings.Split(f.GetName(), ",") {
+				key = strings.TrimSpace(key)
 				if len(key) > 1 {
 					flagName = key
 				}
 
-				if context.IsSet(strings.TrimSpace(key)) {
+				if context.IsSet(key) {
 					flagPresent = true
 				}
 			}

--- a/vendor/github.com/urfave/cli/flag_int64_slice.go
+++ b/vendor/github.com/urfave/cli/flag_int64_slice.go
@@ -171,7 +171,9 @@ func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
 func removeFromInt64Slice(slice []int64, val int64) []int64 {
 	for i, v := range slice {
 		if v == val {
-			return append(slice[:i], slice[i+1:]...)
+			ret := append([]int64{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
 		}
 	}
 	return slice

--- a/vendor/github.com/urfave/cli/flag_int_slice.go
+++ b/vendor/github.com/urfave/cli/flag_int_slice.go
@@ -170,7 +170,9 @@ func lookupIntSlice(name string, set *flag.FlagSet) []int {
 func removeFromIntSlice(slice []int, val int) []int {
 	for i, v := range slice {
 		if v == val {
-			return append(slice[:i], slice[i+1:]...)
+			ret := append([]int{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
 		}
 	}
 	return slice

--- a/vendor/github.com/urfave/cli/flag_string_slice.go
+++ b/vendor/github.com/urfave/cli/flag_string_slice.go
@@ -156,7 +156,9 @@ func lookupStringSlice(name string, set *flag.FlagSet) []string {
 func removeFromStringSlice(slice []string, val string) []string {
 	for i, v := range slice {
 		if v == val {
-			return append(slice[:i], slice[i+1:]...)
+			ret := append([]string{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
 		}
 	}
 	return slice

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
-# github.com/urfave/cli v1.22.4
+# github.com/urfave/cli v1.22.5
 ## explicit
 github.com/urfave/cli
 # github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c


### PR DESCRIPTION
This PR updates the parameters passed to `provision_device` workflow to include `tenant_id` and `device_id` instead of `model.Device`.