### PR TITLE
Fix: return 401 unauthorized on ErrAuthSetNotFound

### DIFF
--- a/api/http/api_devauth.go
+++ b/api/http/api_devauth.go
@@ -440,7 +440,7 @@ func (d *DevAuthApiHandlers) VerifyTokenHandler(w rest.ResponseWriter, r *rest.R
 		switch err {
 		case jwt.ErrTokenExpired:
 			code = http.StatusForbidden
-		case store.ErrTokenNotFound, jwt.ErrTokenInvalid:
+		case store.ErrTokenNotFound, store.ErrAuthSetNotFound, jwt.ErrTokenInvalid:
 			code = http.StatusUnauthorized
 		case cache.ErrTooManyRequests:
 			code = http.StatusTooManyRequests

--- a/api/http/api_devauth_test.go
+++ b/api/http/api_devauth_test.go
@@ -760,6 +760,15 @@ func TestApiDevAuthVerifyToken(t *testing.T) {
 		{
 			req: test.MakeSimpleRequest("POST",
 				"http://1.2.3.4/api/internal/v1/devauth/tokens/verify", nil),
+			code: http.StatusUnauthorized,
+			headers: map[string]string{
+				"authorization": "dummytoken",
+			},
+			err: store.ErrAuthSetNotFound,
+		},
+		{
+			req: test.MakeSimpleRequest("POST",
+				"http://1.2.3.4/api/internal/v1/devauth/tokens/verify", nil),
 			code: 500,
 			body: RestError("internal error"),
 			headers: map[string]string{

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -1160,7 +1160,7 @@ func (d *DevAuth) VerifyToken(ctx context.Context, raw string) error {
 	auth, err := d.db.GetAuthSetById(ctx, jti.String())
 	if err != nil {
 		if err == store.ErrAuthSetNotFound {
-			l.Errorf("Token %s not found", jti)
+			l.Errorf("Auth set %s not found", jti)
 			return err
 		}
 		return err


### PR DESCRIPTION
In case an authset is not found when verifying a JWT token, we returned
500 internal server error. We change the behaviour to return 401
Unauthorized, letting the device to ask for a new JWT token.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>