### PR TITLE
MEN-3763: New endpoint for querying devices with auth sets

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -275,7 +275,11 @@ func updateDevicesStatus(ctx context.Context, db store.DataStore, c cinv.Client,
 
 	skip = 0
 	for {
-		devices, err := db.GetDevices(ctx, skip, devicesBatchSize, model.DeviceFilter{Status: &status})
+		devices, err := db.GetDevices(ctx,
+			skip,
+			devicesBatchSize,
+			model.DeviceFilter{Status: []string{status}},
+		)
 		if err != nil {
 			return errors.Wrap(err, "failed to get devices")
 		}

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -332,7 +332,7 @@ func TestPropagateStatusesInventory(t *testing.T) {
 						context.Background(),
 						uint(0),
 						uint(512),
-						model.DeviceFilter{Status: &deviceStatuses[i]},
+						model.DeviceFilter{Status: []string{deviceStatuses[i]}},
 					).Return(
 						dbs["deviceauth"],
 						tc.errDbDevices,
@@ -351,7 +351,7 @@ func TestPropagateStatusesInventory(t *testing.T) {
 							m,
 							uint(0),
 							uint(512),
-							model.DeviceFilter{Status: &deviceStatuses[i]},
+							model.DeviceFilter{Status: []string{deviceStatuses[i]}},
 						).Return(
 							v,
 							tc.errDbDevices)

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -122,6 +122,79 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /devices/search:
+    post:
+      operationId: Search Devices
+      security:
+        - ManagementJWT: []
+      summary: >-
+        Query for devices. Returns a list of matching devices with AuthSets
+        sorted by age.
+      tags:
+        - Management API
+      parameters:
+        - name: page
+          in: query
+          description: Results page number
+          required: false
+          type: integer
+          default: 1
+        - name: per_page
+          in: query
+          description: Maximum number of results per page.
+          required: false
+          type: integer
+          default: 20
+          maximum: 500
+        - name: filter
+          in: body
+          description: |
+            Device status filter.
+            All properties can be either a single string or an array of strings.
+          required: true
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: >-
+                  Device status filter. Can be an array for querying devices
+                  from multiple device statuses.
+                enum:
+                  - pending
+                  - accepted
+                  - rejected
+                  - preauthorized
+                  - noauth
+              id:
+                type: array
+                items:
+                  type: string
+                  description: >-
+                    Device ID
+                description: >-
+                  Device ID filter. Can be a string for querying for a single device.
+      responses:
+        200:
+          description: Successful response
+          schema:
+            description: Array of devices
+            type: array
+            items:
+                $ref: '#/definitions/Device'
+          headers:
+            Link:
+              type: string
+              description: Pagination link header, we support 'first', 'next', and 'prev'.
+        400:
+          description: Missing/malformed request params.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
   /devices/{id}:
     get:
       operationId: Get Device


### PR DESCRIPTION
New endpoint `POST /api/management/v2/devauth/devices/search`

>    The endpoint acts as a POST form version of
>    GET /api/management/v2/devauth/devices
>    with the exact same parameters. This commit also allows querying over
>    both multiple and singular device statuses and ids to both endpoints.
>    The new POST endpoint accepts both 'application/json' and
>    'application/x-www-form-urlencoded' (the latter will not be enabled by
>    default middleware, however).