### PR TITLE
MEN-4604: make sure the status is propagated to inventory for pending devices

### DIFF
--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -3004,14 +3004,15 @@ func TestDevAuthDeleteAuthSet(t *testing.T) {
 			co.On("SubmitUpdateDeviceStatusJob", ctx,
 				mock.MatchedBy(
 					func(req orchestrator.UpdateDeviceStatusReq) bool {
-						devices, err := json.Marshal([]model.DeviceInventoryUpdate{{Id: tc.devId}})
+						var updates []model.DeviceInventoryUpdate
+						err := json.Unmarshal([]byte(req.Devices), &updates)
 						assert.NoError(t, err)
 						if tc.dbGetDeviceStatusErr == store.ErrAuthSetNotFound {
-							assert.Equal(t, string(devices), req.Devices)
+							assert.Equal(t, tc.devId, updates[0].Id)
 							assert.Equal(t, "noauth", req.Status)
 							return true
 						} else {
-							assert.Equal(t, string(devices), req.Devices)
+							assert.Equal(t, tc.devId, updates[0].Id)
 							assert.Equal(t, tc.dbGetDeviceStatus, req.Status)
 							return true
 						}

--- a/model/device.go
+++ b/model/device.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/model/device.go
+++ b/model/device.go
@@ -82,7 +82,7 @@ func NewDevice(id, id_data, pubkey string) *Device {
 		Id:              id,
 		IdData:          id_data,
 		PubKey:          pubkey,
-		Status:          DevStatusPending,
+		Status:          DevStatusNoAuth,
 		Decommissioning: false,
 		CreatedTs:       now,
 		UpdatedTs:       now,


### PR DESCRIPTION
If the backend is under load (many new devices authorizing), it can
happen the status attribute is not propagated to the inventory service.
This leads to a device not visible in the UI, but correctly provisioned
as pending in deviceauth.

To avoid it we update the flow of the auth request:

1. Default status for devices is noauth
2. Auth request processing happens as usual
3. The workflow execution to update the status in inventory is started
4. If no error happened in 1-3, we updated the status in db to pending

In case of failure, the status in the db will be noauth, which will
trigger a new sync to inventory because noauth != pending.

Changelog: fix status propagation to inventory for pending devices

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit 9b89205e7ca06b993e2c989a495e37cd4ef1c5b2)
Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>