### PR TITLE
tests: Mount volume collecting acceptance tests coverage for open-source

### DIFF
--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -16,6 +16,8 @@ services:
     mender-device-auth:
             # built/tagged locally and only used for testing
             image: mendersoftware/deviceauth:prtest
+            volumes:
+                - "${TESTS_DIR}:/testing"
             environment:
                 # acceptance container will be running mocks for a couple of
                 # services, direct deviceauth there


### PR DESCRIPTION
Randomly discovered this when doing QA-159.