### PR TITLE
MEN-4670: api docs, /auth_requests does not require the JWT token

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -28,8 +28,6 @@ paths:
   /auth_requests:
     post:
       operationId: Authenticate Device
-      security:
-        - DeviceJWT: []
       tags:
         - Device API
       summary: Submit an authentication request


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>