### PR TITLE
removed deprecated ci job image overrides to align with ci templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,10 +25,6 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
 
-test:static:
-  image: golang:1.14
-
 test:unit:
-  image: golang:1.14
   variables:
     DEVICEAUTH_MONGO: mongo


### PR DESCRIPTION
Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>