### PR TITLE
MEN-4525: device provisioning and decommissioning workflow updates

### DIFF
--- a/client/orchestrator/models.go
+++ b/client/orchestrator/models.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -24,9 +24,6 @@ type DecommissioningReq struct {
 	DeviceId string `json:"device_id"`
 	// Request ID
 	RequestId string `json:"request_id"`
-	// User authorization, eg. the value of Authorization header of incoming
-	// HTTP request
-	Authorization string `json:"authorization"`
 	// TenantID
 	TenantID string `json:"tenant_id"`
 }
@@ -35,9 +32,6 @@ type DecommissioningReq struct {
 type ProvisionDeviceReq struct {
 	// Request ID
 	RequestId string `json:"request_id"`
-	// User authorization, eg. the value of Authorization header of incoming
-	// HTTP request
-	Authorization string `json:"authorization"`
 	// DeviceID
 	DeviceID string `json:"device_id"`
 	// TenantID

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -515,10 +515,9 @@ func (d *DevAuth) processPreAuthRequest(ctx context.Context, r *model.AuthReq) (
 		if err := d.cOrch.SubmitProvisionDeviceJob(
 			ctx,
 			orchestrator.ProvisionDeviceReq{
-				RequestId:     reqId,
-				Authorization: ctxhttpheader.FromContext(ctx, "Authorization"),
-				DeviceID:      aset.DeviceId,
-				TenantID:      tenantID,
+				RequestId: reqId,
+				DeviceID:  aset.DeviceId,
+				TenantID:  tenantID,
 			}); err != nil {
 			return nil, errors.Wrap(err, "submit device provisioning job error")
 		}
@@ -713,10 +712,9 @@ func (d *DevAuth) DecommissionDevice(ctx context.Context, devID string) error {
 	if err := d.cOrch.SubmitDeviceDecommisioningJob(
 		ctx,
 		orchestrator.DecommissioningReq{
-			DeviceId:      devID,
-			RequestId:     reqId,
-			Authorization: ctxhttpheader.FromContext(ctx, "Authorization"),
-			TenantID:      tenantID,
+			DeviceId:  devID,
+			RequestId: reqId,
+			TenantID:  tenantID,
 		}); err != nil {
 		return errors.Wrap(err, "submit device decommissioning job error")
 	}
@@ -878,10 +876,9 @@ func (d *DevAuth) AcceptDeviceAuth(ctx context.Context, device_id string, auth_i
 	if err := d.cOrch.SubmitProvisionDeviceJob(
 		ctx,
 		orchestrator.ProvisionDeviceReq{
-			RequestId:     reqId,
-			Authorization: ctxhttpheader.FromContext(ctx, "Authorization"),
-			DeviceID:      aset.DeviceId,
-			TenantID:      tenantID,
+			RequestId: reqId,
+			DeviceID:  aset.DeviceId,
+			TenantID:  tenantID,
 		}); err != nil {
 		return errors.Wrap(err, "submit device provisioning job error")
 	}

--- a/devauth/devauth_test.go
+++ b/devauth/devauth_test.go
@@ -2459,9 +2459,8 @@ func TestDevAuthDecommissionDevice(t *testing.T) {
 			co := morchestrator.ClientRunner{}
 			co.On("SubmitDeviceDecommisioningJob", ctx,
 				orchestrator.DecommissioningReq{
-					DeviceId:      tc.devId,
-					Authorization: tc.coAuthorization,
-					TenantID:      tc.tenant,
+					DeviceId: tc.devId,
+					TenantID: tc.tenant,
 				}).
 				Return(tc.coSubmitDeviceDecommisioningJobErr)
 

--- a/tests/tests/orchestrator.py
+++ b/tests/tests/orchestrator.py
@@ -46,8 +46,6 @@ def decommission_device_handler(device_id=None, status=200):
         assert dreq.get("device_id", None) == device_id
         # test is enforcing particular request ID
         assert dreq.get("request_id", None) == "delete_device"
-        # test is enforcing particular request ID
-        assert dreq.get("authorization", None) == "Bearer foobar"
         return (status, {}, "")
 
     return _decommission_device


### PR DESCRIPTION
The device provisioning and decommissioning workflows don't require the
authorization header anymore.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>