### PR TITLE
Changelog:All: Bump alpine from 3.14.2 to 3.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/mendersoftware/deviceauth
 ADD ./ .
 RUN CGO_ENABLED=0 GOARCH=amd64 go build -o deviceauth .
 
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 EXPOSE 8080
 # mount your private key at /etc/deviceauth/rsa/private.pem
 RUN mkdir -p /etc/deviceauth/rsa

--- a/Dockerfile.acceptance-testing
+++ b/Dockerfile.acceptance-testing
@@ -4,7 +4,7 @@ COPY . /go/src/github.com/mendersoftware/deviceauth
 RUN cd /go/src/github.com/mendersoftware/deviceauth && \
     env CGO_ENABLED=0 go test -c -o deviceauth-test -coverpkg $(go list ./... | grep -v vendor | grep -v mock | grep -v test | tr  '\n' ,)
 
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
 EXPOSE 8080
 


### PR DESCRIPTION
Bumps alpine from 3.14.2 to 3.15.0.

---
updated-dependencies:
- dependency-name: alpine
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit e89cba34a42277836ce051094c8121c519ad5275)
Signed-off-by: Peter Grzybowski <peter@northern.tech>