### PR TITLE
perf(mongo): Sort devices by status then ID for GET /devices

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -225,7 +225,10 @@ func (db *DataStoreMongo) GetDevices(
 		Collection(DbDevicesColl)
 
 	findOpts := mopts.Find().
-		SetSort(bson.D{{Key: "_id", Value: 1}}).
+		SetSort(bson.D{
+			{Key: dbFieldStatus, Value: 1},
+			{Key: dbFieldID, Value: 1},
+		}).
 		SetSkip(int64(skip) & MaxInt64)
 
 	if limit > 0 {


### PR DESCRIPTION
By first sorting by status, the query is always backed by the index `tenant_id_status__id`.