### PR TITLE
chore: enable api docs linter as obligatory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,3 +67,6 @@ publish:image:saas:
 publish:image:mender:
   rules:
     - when: never
+
+test:validate-open-api:
+  allow_failure: false


### PR DESCRIPTION
Ticket: None