### PR TITLE
ALV-213: Handle preauthorized auth sets when device is accepted

### DIFF
--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -488,6 +488,11 @@ func (d *DevAuth) processPreAuthRequest(
 		}
 	}
 
+	// Ensure that the old acceptable auth sets are rejected
+	if err := d.db.RejectAuthSetsForDevice(ctx, aset.DeviceId); err != nil &&
+		!errors.Is(err, store.ErrAuthSetNotFound) {
+		return nil, errors.Wrap(err, "failed to reject auth sets")
+	}
 	update := model.AuthSetUpdate{
 		Status: model.DevStatusAccepted,
 	}

--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -477,16 +477,16 @@ func (d *DevAuth) processPreAuthRequest(
 	currentStatus := dev.Status
 	if dev.Status == model.DevStatusAccepted {
 		deviceAlreadyAccepted = true
-	}
+	} else {
+		// auth set is ok for auto-accepting, check device limit
+		allow, err := d.canAcceptDevice(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-	// auth set is ok for auto-accepting, check device limit
-	allow, err := d.canAcceptDevice(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !allow {
-		return nil, ErrMaxDeviceCountReached
+		if !allow {
+			return nil, ErrMaxDeviceCountReached
+		}
 	}
 
 	update := model.AuthSetUpdate{

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -98,9 +98,9 @@ type DataStore interface {
 
 	GetAuthSetsForDevice(ctx context.Context, devid string) ([]model.AuthSet, error)
 
-	// update matching AuthSets and set their fields to values in AuthSetUpdate
-	UpdateAuthSet(ctx context.Context, filter interface{}, mod model.AuthSetUpdate) error
-
+	// RejectAuthSetsForDevice updates the auth set status for all auth sets
+	// with status "accepted" or "preauthorized" to "rejected"
+	RejectAuthSetsForDevice(ctx context.Context, deviceID string) error
 	UpdateAuthSetById(ctx context.Context, authId string, mod model.AuthSetUpdate) error
 
 	// deletes all auth sets for device

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -481,13 +481,13 @@ func (_m *DataStore) PutLimit(ctx context.Context, lim model.Limit) error {
 	return r0
 }
 
-// StoreMigrationVersion provides a mock function with given fields: ctx, version
-func (_m *DataStore) StoreMigrationVersion(ctx context.Context, version *migrate.Version) error {
-	ret := _m.Called(ctx, version)
+// RejectAuthSetsForDevice provides a mock function with given fields: ctx, deviceID
+func (_m *DataStore) RejectAuthSetsForDevice(ctx context.Context, deviceID string) error {
+	ret := _m.Called(ctx, deviceID)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *migrate.Version) error); ok {
-		r0 = rf(ctx, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, deviceID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -495,13 +495,13 @@ func (_m *DataStore) StoreMigrationVersion(ctx context.Context, version *migrate
 	return r0
 }
 
-// UpdateAuthSet provides a mock function with given fields: ctx, filter, mod
-func (_m *DataStore) UpdateAuthSet(ctx context.Context, filter interface{}, mod model.AuthSetUpdate) error {
-	ret := _m.Called(ctx, filter, mod)
+// StoreMigrationVersion provides a mock function with given fields: ctx, version
+func (_m *DataStore) StoreMigrationVersion(ctx context.Context, version *migrate.Version) error {
+	ret := _m.Called(ctx, version)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, interface{}, model.AuthSetUpdate) error); ok {
-		r0 = rf(ctx, filter, mod)
+	if rf, ok := ret.Get(0).(func(context.Context, *migrate.Version) error); ok {
+		r0 = rf(ctx, version)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
The previous behavior was putting the device in a conflicting state and
returning 500 errors on auth requests. With this PR, the
preauthorized auth set will take precedence and take over as the
accepted auth set.