### PR TITLE
fix: Preauthorize force behavior applies to existing auth sets

### DIFF
--- a/devauth/devauth.go
+++ b/devauth/devauth.go
@@ -1124,7 +1124,7 @@ func (d *DevAuth) PreauthorizeDevice(
 		// if device exists we handle force: just add the authset, if force is in req
 		if req.Force {
 			// record authentication request
-			authset := model.AuthSet{
+			authset := &model.AuthSet{
 				Id:           req.AuthSetId,
 				IdData:       req.IdData,
 				IdDataStruct: idDataStruct,
@@ -1134,7 +1134,7 @@ func (d *DevAuth) PreauthorizeDevice(
 				Status:       model.DevStatusPreauth,
 				Timestamp:    uto.TimePtr(time.Now()),
 			}
-			err = d.db.AddAuthSet(ctx, authset)
+			err = d.db.UpsertAuthSetStatus(ctx, authset)
 			if err != nil {
 				return nil, err
 			}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -87,6 +87,7 @@ type DataStore interface {
 	DeleteDevice(ctx context.Context, id string) error
 
 	AddAuthSet(ctx context.Context, set model.AuthSet) error
+	UpsertAuthSetStatus(ctx context.Context, authSet *model.AuthSet) error
 
 	GetAuthSetByIdDataHashKey(
 		ctx context.Context,

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -560,6 +560,20 @@ func (_m *DataStore) UpdateDevice(ctx context.Context, deviceID string, up model
 	return r0
 }
 
+// UpsertAuthSetStatus provides a mock function with given fields: ctx, authSet
+func (_m *DataStore) UpsertAuthSetStatus(ctx context.Context, authSet model.AuthSet) error {
+	ret := _m.Called(ctx, authSet)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.AuthSet) error); ok {
+		r0 = rf(ctx, authSet)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // WithAutomigrate provides a mock function with given fields:
 func (_m *DataStore) WithAutomigrate() store.DataStore {
 	ret := _m.Called()

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -561,11 +561,11 @@ func (_m *DataStore) UpdateDevice(ctx context.Context, deviceID string, up model
 }
 
 // UpsertAuthSetStatus provides a mock function with given fields: ctx, authSet
-func (_m *DataStore) UpsertAuthSetStatus(ctx context.Context, authSet model.AuthSet) error {
+func (_m *DataStore) UpsertAuthSetStatus(ctx context.Context, authSet *model.AuthSet) error {
 	ret := _m.Called(ctx, authSet)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.AuthSet) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *model.AuthSet) error); ok {
 		r0 = rf(ctx, authSet)
 	} else {
 		r0 = ret.Error(0)


### PR DESCRIPTION
Updates the behavior of the Preauthorize endpoint if "force" paremeter is set:
 * If an authset already exist, the status will be forced to "preauthorized".
 * If the auth set does not exist, a new one will be created.

Changelog: Commit
Ticket: MEN-7241