### PR TITLE
fix: Inconsistent device check_in_time when listing devices

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -433,11 +433,6 @@ func (rl *RedisCache) CacheLimits(
 	return res.Err()
 }
 
-// TODO replace with something
-func (rl *RedisCache) FlushDB(ctx context.Context) error {
-	return rl.c.FlushDBAsync(ctx).Err()
-}
-
 func (rl *RedisCache) KeyQuota(tid, id, idtype, intvlNum string, version int) string {
 	return fmt.Sprintf(
 		"%s:tenant:%s:version:%d:%s:%s:quota:%s",

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -477,7 +477,7 @@ func (rl *RedisCache) KeyTenantVersion(tid string) string {
 // which just means the key was not found, and is normal
 // it's routinely returned e.g. from GET, or pipelines containing it
 func isErrRedisNil(e error) bool {
-	return e.Error() == "redis: nil"
+	return errors.Is(e, redis.Nil)
 }
 
 // TODO: move to go-lib-micro/ratelimits

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -205,63 +205,6 @@ func TestRedisCacheTokenDelete(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRedisCacheFlushDB(t *testing.T) {
-	ctx := context.TODO()
-
-	r := miniredis.NewMiniRedis()
-	err := r.Start()
-	assert.NoError(t, err)
-	defer r.Close()
-
-	rcache, err := NewRedisCache(ctx, "redis://"+r.Addr(), cachePrefix, limitsExpSec)
-
-	// cache 2 tokens and immediately flush
-	rcache.CacheToken(ctx,
-		"tenant-foo",
-		"device-1",
-		IdTypeDevice,
-		"tokenstr-1",
-		time.Duration(10*time.Second))
-
-	rcache.CacheToken(ctx,
-		"tenant-foo",
-		"device-2",
-		IdTypeDevice,
-		"tokenstr-2",
-		time.Duration(10*time.Second))
-
-	err = rcache.FlushDB(ctx)
-	assert.NoError(t, err)
-
-	// no hits after flush
-	tok1, err := rcache.Throttle(ctx,
-		"tokenstr-1",
-		ratelimits.ApiLimits{},
-		"tenant-foo",
-		"device-1",
-		IdTypeDevice,
-		"/some/url",
-		"GET")
-	assert.NoError(t, err)
-	assert.Equal(t, "", tok1)
-
-	tok2, err := rcache.Throttle(ctx,
-		"tokenstr-2",
-		ratelimits.ApiLimits{},
-		"tenant-foo",
-		"device-2",
-		IdTypeDevice,
-		"/some/url",
-		"GET")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "", tok2)
-
-	// second delete (no token) doesn't trigger an error
-	err = rcache.DeleteToken(ctx, "tenant-foo", "device-1", IdTypeDevice)
-	assert.NoError(t, err)
-}
-
 func TestRedisCacheLimitsQuota(t *testing.T) {
 	r := miniredis.NewMiniRedis()
 	err := r.Start()


### PR DESCRIPTION
The lookup for `check_in_time` from the cache does not work when running
Redis in cluster mode because of the MGET command requires keys to hash
to the same slot. This commit replaces MGET with multiple batched GET
commands when running Redis in cluster mode.

Changelog: Commit
Ticket: MEN-7337